### PR TITLE
Mount filtered dstack broker into attested app containers (#3)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,22 +13,23 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/dstack.sock:/var/run/dstack.sock:ro
       - daemon_data:/var/lib/tee-daemon
-      # Named volume backing PROXY_SOCKET_DIR. The daemon serves the already-
-      # filtered dstack broker at <PROXY_SOCKET_DIR>/dstack.sock here; attested
-      # app containers mount the same volume at /var/run (see PROXY_VOLUME_NAME),
-      # so the broker appears at /var/run/dstack.sock inside them.
-      - proxy_sock:/var/run/proxy
+      # Broker-ONLY named volume. The daemon serves the already-filtered dstack
+      # broker at <BROKER_SOCKET_DIR>/dstack.sock here and nothing else (NOT
+      # docker.sock, which stays in PROXY_DIR off this volume). Attested app
+      # containers mount the same volume at /run/broker (see BROKER_VOLUME_NAME),
+      # so the broker appears at /run/broker/dstack.sock inside them.
+      - broker_sock:/var/run/broker
     environment:
       - TEE_DAEMON_TOKEN=${TEE_DAEMON_TOKEN}
       - DAEMON_VOLUME_NAME=${DAEMON_VOLUME_NAME:-}
       - DAEMON_VOLUME_MOUNT=${DAEMON_VOLUME_MOUNT:-/var/lib/tee-daemon}
-      # Set to the *resolved* docker volume name of proxy_sock (compose prefixes
-      # it with the project name, e.g. "dstack_proxy_sock"), mirroring how
-      # DAEMON_VOLUME_NAME is wired. When set, attested app containers get the
-      # broker mounted at /var/run/dstack.sock. Leave empty to disable.
-      - PROXY_VOLUME_NAME=${PROXY_VOLUME_NAME:-}
-      - PROXY_SOCKET_DIR=${PROXY_SOCKET_DIR:-/var/run/proxy}
+      # Set to the *resolved* docker volume name of broker_sock (compose prefixes
+      # it with the project name, e.g. "dstack_broker_sock"), mirroring how
+      # DAEMON_VOLUME_NAME is wired. When set, attested app containers get ONLY
+      # the broker mounted at /run/broker/dstack.sock. Leave empty to disable.
+      - BROKER_VOLUME_NAME=${BROKER_VOLUME_NAME:-}
+      - BROKER_SOCKET_DIR=${BROKER_SOCKET_DIR:-/var/run/broker}
 
 volumes:
   daemon_data:
-  proxy_sock:
+  broker_sock:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,10 +13,22 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/dstack.sock:/var/run/dstack.sock:ro
       - daemon_data:/var/lib/tee-daemon
+      # Named volume backing PROXY_SOCKET_DIR. The daemon serves the already-
+      # filtered dstack broker at <PROXY_SOCKET_DIR>/dstack.sock here; attested
+      # app containers mount the same volume at /var/run (see PROXY_VOLUME_NAME),
+      # so the broker appears at /var/run/dstack.sock inside them.
+      - proxy_sock:/var/run/proxy
     environment:
       - TEE_DAEMON_TOKEN=${TEE_DAEMON_TOKEN}
       - DAEMON_VOLUME_NAME=${DAEMON_VOLUME_NAME:-}
       - DAEMON_VOLUME_MOUNT=${DAEMON_VOLUME_MOUNT:-/var/lib/tee-daemon}
+      # Set to the *resolved* docker volume name of proxy_sock (compose prefixes
+      # it with the project name, e.g. "dstack_proxy_sock"), mirroring how
+      # DAEMON_VOLUME_NAME is wired. When set, attested app containers get the
+      # broker mounted at /var/run/dstack.sock. Leave empty to disable.
+      - PROXY_VOLUME_NAME=${PROXY_VOLUME_NAME:-}
+      - PROXY_SOCKET_DIR=${PROXY_SOCKET_DIR:-/var/run/proxy}
 
 volumes:
   daemon_data:
+  proxy_sock:

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -82,7 +82,10 @@ async def start():
         await dstack_runner.setup()
         await web.UnixSite(dstack_runner, dstack_sock_path).start()
         os.chmod(dstack_sock_path, 0o666)
-        log.info("dstack proxy listening on %s", dstack_sock_path)
+        log.info("dstack proxy (filtered broker) listening on %s", dstack_sock_path)
+        if os.environ.get("PROXY_VOLUME_NAME"):
+            log.info("Broker shared to attested apps via PROXY_VOLUME_NAME=%s "
+                     "(appears at /var/run/dstack.sock)", os.environ["PROXY_VOLUME_NAME"])
     else:
         log.warning("dstack socket not found — dstack proxy disabled")
 

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -22,6 +22,9 @@ logging.basicConfig(level=logging.INFO, format="[%(name)s] %(message)s")
 log = logging.getLogger("tee-daemon")
 
 PROXY_DIR = os.environ.get("PROXY_SOCKET_DIR", "/var/run/proxy")
+# Broker socket lives in its OWN dir, separate from PROXY_DIR (which holds
+# docker.sock). Only this dir is shared into attested apps — never docker.sock.
+BROKER_SOCKET_DIR = os.environ.get("BROKER_SOCKET_DIR", "/var/run/broker")
 DOCKER_SOCK = os.environ.get("DOCKER_SOCKET", "/var/run/docker.sock")
 DSTACK_SOCK = os.environ.get("DSTACK_SOCKET", "/var/run/dstack.sock")
 DATA_DIR = os.environ.get("DAEMON_DATA_DIR", "/var/lib/tee-daemon/projects")
@@ -32,6 +35,7 @@ INGRESS_PORT = int(os.environ.get("INGRESS_PORT", "8080"))
 
 async def start():
     os.makedirs(PROXY_DIR, exist_ok=True)
+    os.makedirs(BROKER_SOCKET_DIR, exist_ok=True)
 
     dstack_sock = DSTACK_SOCK if os.path.exists(DSTACK_SOCK) else None
     ingress_mod.DSTACK_SOCK = dstack_sock
@@ -75,7 +79,9 @@ async def start():
         dstack_proxy = DstackProxy(dstack_sock)
         dstack_app = web.Application()
         dstack_app.router.add_route("*", "/{path:.*}", dstack_proxy.handle)
-        dstack_sock_path = os.path.join(PROXY_DIR, "dstack.sock")
+        # Serve in BROKER_SOCKET_DIR (NOT PROXY_DIR) so apps can be given the
+        # broker without also getting docker.sock.
+        dstack_sock_path = os.path.join(BROKER_SOCKET_DIR, "dstack.sock")
         if os.path.exists(dstack_sock_path):
             os.unlink(dstack_sock_path)
         dstack_runner = web.AppRunner(dstack_app)
@@ -83,9 +89,9 @@ async def start():
         await web.UnixSite(dstack_runner, dstack_sock_path).start()
         os.chmod(dstack_sock_path, 0o666)
         log.info("dstack proxy (filtered broker) listening on %s", dstack_sock_path)
-        if os.environ.get("PROXY_VOLUME_NAME"):
-            log.info("Broker shared to attested apps via PROXY_VOLUME_NAME=%s "
-                     "(appears at /var/run/dstack.sock)", os.environ["PROXY_VOLUME_NAME"])
+        if os.environ.get("BROKER_VOLUME_NAME"):
+            log.info("Broker shared to attested apps via BROKER_VOLUME_NAME=%s "
+                     "(appears at /run/broker/dstack.sock)", os.environ["BROKER_VOLUME_NAME"])
     else:
         log.warning("dstack socket not found — dstack proxy disabled")
 

--- a/proxy/runtimes.py
+++ b/proxy/runtimes.py
@@ -23,21 +23,25 @@ VOLUME_MOUNT = os.environ.get("DAEMON_VOLUME_MOUNT", "/var/lib/tee-daemon")
 # to each handler. Projects use it for persistent state (DBs, subs, etc.).
 DATA_VOLUME_NAME = os.environ.get("DAEMON_DATA_VOLUME_NAME", "")
 DATA_VOLUME_MOUNT_IN_RUNTIME = "/daemon-data"
-# Named volume backing the daemon's PROXY_SOCKET_DIR, which holds the already-
-# filtered dstack broker socket (proxy/main.py serves it at PROXY_DIR/dstack.sock).
-# Under Docker-in-Docker the daemon can't bind its own PROXY_DIR into sibling app
-# containers via a host path, so the broker must live on a named volume mounted by
-# both. When set, attested app containers mount it at /var/run so the broker
-# appears at /var/run/dstack.sock. Mirrors DAEMON_VOLUME_NAME.
-PROXY_VOLUME_NAME = os.environ.get("PROXY_VOLUME_NAME", "")
+# Named volume backing the daemon's BROKER_SOCKET_DIR, which holds ONLY the
+# already-filtered dstack broker socket (proxy/main.py serves it at
+# BROKER_SOCKET_DIR/dstack.sock). It is deliberately separate from PROXY_DIR,
+# which also holds docker.sock (the docker-control proxy) — apps must NOT get
+# that. Under Docker-in-Docker the daemon can't bind a host path into sibling
+# containers, so the broker lives on a named volume mounted by both. When set,
+# attested app containers mount it at /run/broker (broker at
+# /run/broker/dstack.sock; nothing else). Mirrors DAEMON_VOLUME_NAME.
+BROKER_VOLUME_NAME = os.environ.get("BROKER_VOLUME_NAME", "")
+BROKER_MOUNT_IN_APP = "/run/broker"
 
 
 def _attested_broker_binds(mode: str) -> list[str]:
-    """Bind the filtered dstack broker socket into attested app containers.
+    """Bind ONLY the filtered dstack broker socket into attested app containers,
+    at a dedicated path (no docker.sock, no /var/run clobber).
     Read-only is fine: connect() doesn't write the socket file."""
-    if mode != "attested" or not PROXY_VOLUME_NAME:
+    if mode != "attested" or not BROKER_VOLUME_NAME:
         return []
-    return [f"{PROXY_VOLUME_NAME}:/var/run:ro"]
+    return [f"{BROKER_VOLUME_NAME}:{BROKER_MOUNT_IN_APP}:ro"]
 # Optional OCI runtime for daemon-managed containers (e.g. "sysbox-runc").
 # Empty string keeps Docker's default (runc).
 CONTAINER_RUNTIME = os.environ.get("DAEMON_CONTAINER_RUNTIME", "")
@@ -449,7 +453,7 @@ class RuntimeManager:
 
         broker_binds = _attested_broker_binds(project.mode)
         binds += broker_binds
-        broker_sock = "/var/run/dstack.sock" if broker_binds else ""
+        broker_sock = f"{BROKER_MOUNT_IN_APP}/dstack.sock" if broker_binds else ""
 
         labels = {
             "tee-proxy.managed": "true",

--- a/proxy/runtimes.py
+++ b/proxy/runtimes.py
@@ -23,6 +23,21 @@ VOLUME_MOUNT = os.environ.get("DAEMON_VOLUME_MOUNT", "/var/lib/tee-daemon")
 # to each handler. Projects use it for persistent state (DBs, subs, etc.).
 DATA_VOLUME_NAME = os.environ.get("DAEMON_DATA_VOLUME_NAME", "")
 DATA_VOLUME_MOUNT_IN_RUNTIME = "/daemon-data"
+# Named volume backing the daemon's PROXY_SOCKET_DIR, which holds the already-
+# filtered dstack broker socket (proxy/main.py serves it at PROXY_DIR/dstack.sock).
+# Under Docker-in-Docker the daemon can't bind its own PROXY_DIR into sibling app
+# containers via a host path, so the broker must live on a named volume mounted by
+# both. When set, attested app containers mount it at /var/run so the broker
+# appears at /var/run/dstack.sock. Mirrors DAEMON_VOLUME_NAME.
+PROXY_VOLUME_NAME = os.environ.get("PROXY_VOLUME_NAME", "")
+
+
+def _attested_broker_binds(mode: str) -> list[str]:
+    """Bind the filtered dstack broker socket into attested app containers.
+    Read-only is fine: connect() doesn't write the socket file."""
+    if mode != "attested" or not PROXY_VOLUME_NAME:
+        return []
+    return [f"{PROXY_VOLUME_NAME}:/var/run:ro"]
 # Optional OCI runtime for daemon-managed containers (e.g. "sysbox-runc").
 # Empty string keeps Docker's default (runc).
 CONTAINER_RUNTIME = os.environ.get("DAEMON_CONTAINER_RUNTIME", "")
@@ -331,6 +346,9 @@ class RuntimeManager:
                 binds.append(f"{DATA_VOLUME_NAME}:{DATA_VOLUME_MOUNT_IN_RUNTIME}:rw")
                 data_root = DATA_VOLUME_MOUNT_IN_RUNTIME
 
+            # Expose the filtered dstack broker to attested shared-runtime tenants.
+            binds += _attested_broker_binds(mode)
+
             # Write router with correct projects root, filtering by mode
             router_code = config["router_code"].replace("/projects/", f"{projects_root}/").replace('"/projects"', f'"{projects_root}"')
             router_code = router_code.replace("__DATA_ROOT__", data_root)
@@ -429,6 +447,10 @@ class RuntimeManager:
         binds.append(f"{proj_data_volume}:/data:rw")
         data_dir_in = "/data"
 
+        broker_binds = _attested_broker_binds(project.mode)
+        binds += broker_binds
+        broker_sock = "/var/run/dstack.sock" if broker_binds else ""
+
         labels = {
             "tee-proxy.managed": "true",
             "tee-daemon.runtime": project.runtime,
@@ -438,14 +460,16 @@ class RuntimeManager:
         if project.mode == "attested":
             labels["tee-daemon.attested"] = "true"
 
+        read_paths = [files_in, entry_in] + ([data_dir_in] if data_dir_in else []) + ([broker_sock] if broker_sock else [])
+        write_paths = ([data_dir_in] if data_dir_in else []) + ([broker_sock] if broker_sock else [])
         cmd = [
             "deno", "run", "--no-prompt",
-            f"--allow-read={files_in},{entry_in}" + (f",{data_dir_in}" if data_dir_in else ""),
+            f"--allow-read={','.join(read_paths)}",
             "--allow-net",
             "--deny-env", "--deny-ffi", "--deny-run", "--deny-sys",
         ]
-        if data_dir_in:
-            cmd.append(f"--allow-write={data_dir_in}")
+        if write_paths:
+            cmd.append(f"--allow-write={','.join(write_paths)}")
         cmd += [
             entry_in,
             project.entry or "server.ts",
@@ -488,7 +512,7 @@ class RuntimeManager:
             await self.docker.stop(existing)
             await self.docker.remove(existing)
             self.tracker.remove(existing)
-        binds = []
+        binds = list(_attested_broker_binds(project.mode))
         for v in project.volumes or []:
             await self.docker.ensure_volume(v["name"])
             binds.append(f"{v['name']}:{v['mount']}")


### PR DESCRIPTION
Closes #3

## What changed

Wires the daemon's **already-built, already-filtered** dstack broker into **attested** app containers so an attested app can reach filtered dstack at `/run/broker/dstack.sock` (`GetKey` pinned to `/tee-daemon/`, `GetQuote`, `Info`, `GetTlsKey`, `EmitEvent`). This adds **no new capability** — it only exposes the existing broker that `proxy/dstack_proxy.py` already filters. No key injection, no new privileged behavior.

- `proxy/main.py` — serve the dstack broker in its **own** dir `BROKER_SOCKET_DIR` (default `/var/run/broker`), separate from `PROXY_DIR` which still holds `docker.sock`. Keeps the 0666 chmod.
- `proxy/runtimes.py` — `BROKER_VOLUME_NAME` env + `_attested_broker_binds(mode)` helper. Returns `["<vol>:/run/broker:ro"]` only when `mode == "attested"` and the env is set; `[]` otherwise. Applied to all three app-container paths (`start_image`, `start_isolated`, shared-runtime `refresh`). Isolated deno additionally gets `--allow-read`/`--allow-write` scoped to `/run/broker/dstack.sock`.
- `docker-compose.yaml` — a **broker-only** named volume `broker_sock` mounted at `/var/run/broker` on the daemon, plus `BROKER_VOLUME_NAME` / `BROKER_SOCKET_DIR` env. `docker.sock` is deliberately NOT on this volume.

## Why a dedicated broker dir (security)

`docker.sock` (the docker-control proxy) lives in `PROXY_DIR`. Sharing all of `PROXY_DIR` into apps would hand them the Docker control plane (privilege escalation) and shadow their `/var/run`. So the broker is served in its own `BROKER_SOCKET_DIR`, backed by its own `broker_sock` volume, mounted into attested apps at the dedicated path `/run/broker` (read-only). Apps get `dstack.sock` and nothing else — no `docker.sock`, no `/var/run` clobber.

## DinD / named-volume rationale

App containers are siblings created via the docker proxy, so the daemon's broker dir can't be bind-mounted into them by host path (same constraint as `DAEMON_VOLUME_NAME`). The broker socket must live on a named volume both sides mount: the daemon at `BROKER_SOCKET_DIR` (volume root holds `dstack.sock`), the attested app at `/run/broker`. Read-only on the app side is fine — `connect()` doesn't write the socket. Gated strictly on `mode == "attested"`; dev apps and the env-unset case get nothing (behavior identical to today when `BROKER_VOLUME_NAME` is empty).

## Operator step (required to activate)

Compose prefixes volume names with the project name, so the daemon can't know the resolved `broker_sock` name at build time (identical to `DAEMON_VOLUME_NAME`). After `docker compose up`, set `BROKER_VOLUME_NAME` to the resolved volume name (e.g. `dstack_broker_sock`, from `docker volume ls`) and redeploy. With it empty, the daemon behaves exactly as before this PR.

## How to verify

From an attested app container:

```
curl --unix-socket /run/broker/dstack.sock \
  -d '{"path":"/tee-daemon/projects/<name>/data"}' \
  http://localhost/GetKey
```

Should return a key. A denied method or out-of-prefix `GetKey` path still 403s (filtering unchanged). `ls /run/broker` shows only `dstack.sock` — no `docker.sock`.

## Tests

`test_daemon.py` is a live-daemon + Docker + Playwright e2e harness with no broker-socket coverage; its deps (`requests`, `playwright`) aren't installed in this env so it wasn't run. Verified: `ast.parse` of changed Python, module import, `_attested_broker_binds` returns the `/run/broker` bind for attested+env-set and `[]` for dev / env-unset, `docker-compose.yaml` parses as valid YAML, and `docker.sock` is served only under `PROXY_DIR` (never `BROKER_SOCKET_DIR`) and is not on the `broker_sock` volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
