### PR TITLE
feat: per-project oci_runtime override (interim runc unblock for broker access)

### DIFF
--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -279,11 +279,13 @@ async def _deploy_image(store: ProjectStore, audit_manager,
 
     volumes = manifest.get("volumes", []) or []
     env_passthrough = manifest.get("env_passthrough", []) or []
+    oci_runtime = manifest.get("oci_runtime", "")
     project = Project(
         name=name, runtime="image", entry="", port=0, mode=mode,
         env=env_vars, deployed_at=datetime.now(timezone.utc).isoformat(),
         image=image, image_port=image_port, volumes=volumes,
         env_passthrough=env_passthrough, listen=listen_config,
+        oci_runtime=oci_runtime,
     )
     store.save(project)
 

--- a/proxy/projects.py
+++ b/proxy/projects.py
@@ -35,6 +35,7 @@ class Project:
     volumes: List[dict] = field(default_factory=list)
     isolation: str = "shared"
     env_passthrough: List[str] = field(default_factory=list)
+    oci_runtime: str = ""
 
     def __post_init__(self):
         if self.env is None:

--- a/proxy/runtimes.py
+++ b/proxy/runtimes.py
@@ -532,9 +532,10 @@ class RuntimeManager:
             val = os.environ.get(key)
             if val is not None:
                 env.append(f"{key}={val}")
+        runtime = project.oci_runtime or CONTAINER_RUNTIME
         cid = await self.docker.create_container(
             cname, project.image, [], binds, labels, network,
-            env=env, runtime=CONTAINER_RUNTIME)
+            env=env, runtime=runtime)
         await self.docker.start(cid)
         self.tracker.add(cid)
         ip = await self.docker.container_ip(cid, network)


### PR DESCRIPTION
Part of #6.

## What
Per-project OCI runtime override for **image** projects. A project can opt out of the daemon's default `DAEMON_CONTAINER_RUNTIME` (runsc/gVisor) and run under a specified OCI runtime via a manifest field:

```json
{ "runtime": "image", "image": "...", "image_port": 8080, "oci_runtime": "runc" }
```

`oci_runtime: "runc"` selects Docker's default runc. Unset → identical to today.

## Why (interim, trusted-tenant only)
PR #4 mounts the filtered dstack broker as a unix socket into attested app containers, but tenants run under gVisor (runsc), which has its own kernel and cannot `connect()` to a host/runc-owned unix socket — so attested tenants can't reach the broker (curl exit 7). This override lets a **trusted** data-plane tenant pin `runc` and reach the broker socket today.

This is an interim unblock and is only acceptable for TRUSTED tenants. The real gVisor fix (host-UDS runsc variant, or a TCP broker + `BROKER_URL`) for UNTRUSTED tenants is tracked in **#6**.

## Changes
- `proxy/projects.py`: add `Project.oci_runtime` (default `""`, serialized via `asdict`; legacy JSON without the field loads fine).
- `proxy/deploy.py`: `_deploy_image` reads `manifest.get("oci_runtime", "")` into the Project.
- `proxy/runtimes.py`: `start_image` uses `runtime = project.oci_runtime or CONTAINER_RUNTIME` and passes it to `create_container`.

Shared-runtime and `isolation:container` paths are untouched. `ast.parse` clean; Project round-trip + default + legacy-missing + `runc` override verified. `test_daemon.py` is a live-docker e2e (not run here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
