### PR TITLE
fix #1: image-runtime deploy preserves source/ref/commit_sha/tree_hash

### DIFF
--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -285,6 +285,8 @@ async def _deploy_image(store: ProjectStore, audit_manager,
     project = Project(
         name=name, runtime="image", entry="", port=0, mode=mode,
         env=env_vars, deployed_at=datetime.now(timezone.utc).isoformat(),
+        source=manifest.get("source", ""), ref=manifest.get("ref", ""),
+        commit_sha=manifest.get("commit_sha", ""), tree_hash=manifest.get("tree_hash", ""),
         image=image, image_port=image_port, volumes=volumes,
         env_passthrough=env_passthrough, listen=listen_config,
         oci_runtime=manifest.get("oci_runtime", ""),

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -322,6 +322,10 @@ def test_deploy_image():
         "runtime": "image",
         "image": "nginx:alpine",
         "image_port": 80,
+        "source": "image://nginx",
+        "ref": "alpine",
+        "commit_sha": "nginx-alpine",
+        "tree_hash": "image-nginx-alpine",
     }
     resp = api_post("/projects", json=manifest)
     assert resp.status_code == 201, f"Deploy failed: {resp.status_code} {resp.text}"
@@ -329,6 +333,10 @@ def test_deploy_image():
     assert project["runtime"] == "image"
     assert project["image"] == "nginx:alpine"
     assert project["image_port"] == 80
+    assert project["source"] == "image://nginx"
+    assert project["ref"] == "alpine"
+    assert project["commit_sha"] == "nginx-alpine"
+    assert project["tree_hash"] == "image-nginx-alpine"
     assert project["image_digest"], "image_digest should be populated after pull"
     print(f"  Deployed: image={project['image']} digest={project['image_digest'][:19]}")
 


### PR DESCRIPTION
Fixes #1. `_deploy_image` (`proxy/deploy.py`) now forwards the manifest's `source`/`ref`/`commit_sha`/`tree_hash` into the stored `Project`, mirroring the git-clone `deploy()` path — so image-runtime tenants (e.g. `probe`) show their source in `/_api/projects`, `/_api/verification`, and the listing card. Trust model unchanged (the image digest is still the binding); this is navigational metadata.

Adds regression assertions to `test_deploy_image`. **Full suite green** — verified from the overseer with real docker (the codex worker couldn't run it: its sandbox blocks `docker.sock` and `.git`, so editing happened in the worktree and verification+commit were done here).

Daemon-internal change → human review (not auto-merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)