### PR TITLE
#10: self-contained About page served by the daemon

### DIFF
--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -84,6 +84,12 @@ class Ingress:
         parts = path.split("/", 1)
         name = parts[0] if parts[0] else ""
 
+        if name in ("about", "_about") and (len(parts) == 1 or not parts[1]):
+            template_path = os.path.join(
+                os.path.dirname(__file__), "templates", "about.html")
+            with open(template_path) as f:
+                return web.Response(text=f.read(), content_type="text/html")
+
         if not name:
             # Public listing. Browsers (Accept: text/html) get the default
             # viewer page; programmatic callers get JSON. Anonymous callers

--- a/proxy/templates/about.html
+++ b/proxy/templates/about.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>About tee-daemon</title>
+<style>
+  :root { color-scheme: light; }
+  * { box-sizing: border-box; }
+  body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; color: #0f1419; background: #f1f4f8; line-height: 1.55; }
+  .header { background: #0d1b2e; background-image: linear-gradient(rgba(31,111,235,0.10) 1px, transparent 1px), linear-gradient(90deg, rgba(31,111,235,0.10) 1px, transparent 1px); background-size: 32px 32px; color: #fff; padding: 2.25rem 1.5rem; }
+  .header .wrap { max-width: 56rem; margin: 0 auto; }
+  .header h1 { margin: 0 0 0.4rem; font-size: 1.5rem; font-weight: 600; letter-spacing: -0.015em; }
+  .header p { margin: 0; opacity: 0.85; font-size: 0.95rem; }
+  .header a { color: #8ab4f8; text-decoration: none; }
+  .header a:hover { text-decoration: underline; }
+  main { max-width: 56rem; margin: 1.5rem auto 3rem; padding: 0 1.5rem; }
+  .card-list { background: #fff; border: 1px solid #e1e4e8; border-radius: 10px; padding: 1.25rem; box-shadow: 0 2px 12px rgba(13,27,46,0.04); }
+  section + section { margin-top: 1rem; }
+  h2 { font-size: 1.15rem; margin: 0 0 0.65rem; font-weight: 600; }
+  p { margin: 0.65rem 0 0; }
+  ul { margin: 0.65rem 0 0; padding-left: 1.2rem; }
+  li + li { margin-top: 0.45rem; }
+  .footer { max-width: 56rem; margin: 0 auto; padding: 0 1.5rem 2rem; color: #57606a; font-size: 0.85em; }
+  .footer a, main a { color: #1f6feb; text-decoration: none; }
+  .footer a:hover, main a:hover { text-decoration: underline; }
+</style>
+</head>
+<body>
+<header class="header">
+  <div class="wrap">
+    <h1>About tee-daemon</h1>
+    <p>A personal Vercel for attestable web apps, served from inside this CVM.</p>
+  </div>
+</header>
+<main>
+  <section class="card-list">
+    <h2>A personal Vercel for attestable web apps</h2>
+    <p>Lambda, Vercel, and Cloudflare Workers host code cheaply and call it on demand. None of them tell the consumer of the output what code ran. For most apps that's fine. For receipts, credentials, sealed-time releases, or evidence in disputes, it's the whole point.</p>
+    <p>A function running inside a Phala dstack TEE can answer that question. The platform produces a hardware-rooted attestation that binds the running code's measurements into the output. tee-daemon wraps that into a normal dev loop: push to a git repo, deploy to your CVM, promote to attested when you're ready, share the URL.</p>
+    <p>Whoever you share with sees the source on GitHub and the running code as the same thing.</p>
+  </section>
+
+  <section class="card-list">
+    <h2>Two modes per project</h2>
+    <p><strong>Dev</strong> is for iteration. Push code, test, change it, throw it away. No audit log, no public verifier; trust is whatever you'd get on Vercel.</p>
+    <p><strong>Attested</strong> is the trust claim. The daemon records the source hash, opens an audit log, binds the hash into the TEE quote, and exposes the verifier endpoints to anonymous callers. Promotion is deliberate, like cutting a release.</p>
+    <p>A single CVM holds as many of each as you like. Most apps stay private. You share the URL of an attested project when someone needs to verify it.</p>
+  </section>
+
+  <section class="card-list">
+    <h2>Why audits stay small</h2>
+    <p>Every project on a tee-daemon CVM rides the same daemon, the same shared runtime, and the same verifier surface. An auditor learns that substrate once, then reuses the understanding across every project they review on it.</p>
+    <p>A specific project's audit reduces to: given this known substrate, does this small handler hold the invariant it claims? The platform's payoff is keeping each per-project audit small.</p>
+  </section>
+</main>
+<div class="footer">
+  <a href="/">Apps deployed here</a>
+  ·
+  <a href="https://amiller.github.io/dstack-webhost/" target="_blank">Project docs</a>
+</div>
+</body>
+</html>

--- a/proxy/templates/index.html
+++ b/proxy/templates/index.html
@@ -47,6 +47,8 @@
   Each card opens the running app, walks the trust chain via the verifier, or jumps to the source on GitHub.
   Only <em>attested</em> apps are listed; dev-mode apps stay private.
   ·
+  <a href="/about">About this CVM</a>
+  ·
   <a href="https://amiller.github.io/dstack-webhost/" target="_blank">About this platform →</a>
 </div>
 <script>


### PR DESCRIPTION
Closes #10. Serves a self-contained About page (`/about`) from the daemon — concept copy ported from `index.md`. **Auto-merged (low-risk):** `auto-ok` docs task, templates + one HTML route only (no security paths, no new deps), judge-approved, full suite green (verified with real docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)