### PR TITLE
#9 (investigation): transparent broker response forwarding — NEEDS LIVE VERIFICATION

### DIFF
--- a/proxy/dstack_proxy.py
+++ b/proxy/dstack_proxy.py
@@ -40,19 +40,32 @@ class DstackProxy:
                     status=403,
                 )
 
-        return await self._forward(request.method, request.path, body_bytes, request.headers)
+        return await self._forward(request.method, request.raw_path, body_bytes, request.headers)
 
     async def _forward(self, method: str, path: str, body: bytes, headers) -> web.Response:
         fwd_headers = {k: v for k, v in headers.items()
                        if k.lower() not in ("host", "transfer-encoding")}
         conn = aiohttp.UnixConnector(path=self.real_socket)
-        async with aiohttp.ClientSession(connector=conn) as session:
+        async with aiohttp.ClientSession(connector=conn, auto_decompress=False) as session:
             async with session.request(method, f"http://localhost{path}",
                                        data=body if body else None,
                                        headers=fwd_headers) as resp:
                 resp_body = await resp.read()
+                resp_headers = {
+                    k: v for k, v in resp.headers.items()
+                    if k.lower() not in (
+                        "connection",
+                        "keep-alive",
+                        "proxy-authenticate",
+                        "proxy-authorization",
+                        "te",
+                        "trailer",
+                        "transfer-encoding",
+                        "upgrade",
+                    )
+                }
                 return web.Response(
                     body=resp_body,
                     status=resp.status,
-                    content_type=resp.content_type,
+                    headers=resp_headers,
                 )


### PR DESCRIPTION
Refs #9. **Investigation result — do NOT merge until live-verified.**

The worker made the broker (`proxy/dstack_proxy.py`) forward responses transparently: `request.raw_path`, `auto_decompress=False`, and pass through upstream response headers (minus hop-by-hop) instead of only `content_type`. Plausible cause for tinycloud's `get_info()` → `classic`: the old code stripped headers / re-encoded the `/Info` body.

**Why this is review-only, not auto-merged:**
- **Unverified** against the live tinycloud+broker (can't be reproduced in a worktree).
- **Changes forwarding for ALL endpoints**, including the currently-working `GetKey` — regression risk on the working path.
- It's the **security-sensitive broker** (cf. #7).

**Verify on the CVM before merging:**
```sh
curl --unix-socket /run/broker/dstack.sock -i http://localhost/Info
curl --unix-socket /var/run/dstack.sock   -i http://localhost/Info   # compare
# confirm GetKey still works after the change:
curl --unix-socket /run/broker/dstack.sock -i -H 'content-type: application/json' \
  --data '{"path":"/tee-daemon/projects/tinycloud-node"}' http://localhost/GetKey
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)