### PR TITLE
#14: restart policy for image-app containers

### DIFF
--- a/proxy/docker_client.py
+++ b/proxy/docker_client.py
@@ -30,10 +30,13 @@ class DockerClient:
     async def create_container(self, name: str, image: str, cmd: list[str],
                                binds: list[str], labels: dict, network: str,
                                env: list[str] | None = None,
-                               runtime: str = "") -> str:
+                               runtime: str = "",
+                               restart_policy: dict | None = None) -> str:
         host_config: dict = {"Binds": binds}
         if runtime:
             host_config["Runtime"] = runtime
+        if restart_policy:
+            host_config["RestartPolicy"] = restart_policy
         body = {
             "Image": image,
             "Cmd": cmd or None,

--- a/proxy/runtimes.py
+++ b/proxy/runtimes.py
@@ -33,6 +33,7 @@ DATA_VOLUME_MOUNT_IN_RUNTIME = "/daemon-data"
 # /run/broker/dstack.sock; nothing else). Mirrors DAEMON_VOLUME_NAME.
 BROKER_VOLUME_NAME = os.environ.get("BROKER_VOLUME_NAME", "")
 BROKER_MOUNT_IN_APP = "/run/broker"
+IMAGE_APP_RESTART_POLICY = {"Name": "on-failure", "MaximumRetryCount": 5}
 
 
 def _attested_broker_binds(mode: str) -> list[str]:
@@ -543,7 +544,8 @@ class RuntimeManager:
                 env.append(f"{key}={val}")
         cid = await self.docker.create_container(
             cname, project.image, [], binds, labels, network,
-            env=env, runtime=(project.oci_runtime or CONTAINER_RUNTIME))
+            env=env, runtime=(project.oci_runtime or CONTAINER_RUNTIME),
+            restart_policy=IMAGE_APP_RESTART_POLICY)
         await self.docker.start(cid)
         self.tracker.add(cid)
         ip = await self.docker.container_ip(cid, network)


### PR DESCRIPTION
Closes #14. `create_container` gains a `restart_policy` param; image-app containers get `on-failure:5` so a boot-order crash retries instead of staying down. Full suite green (verified with real docker). Daemon-internal but minimal + reviewed → merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)