### PR TITLE
fix(runsc-prelaunch): bump pinned runsc sha512 (gVisor latest rolled, wedged CVM boot)

### DIFF
--- a/examples/runsc-prelaunch/prelaunch.sh
+++ b/examples/runsc-prelaunch/prelaunch.sh
@@ -11,12 +11,14 @@
 # of Sentry mediating syscalls.
 set -euo pipefail
 
-# NOTE 2026-06-12: 'latest' rolled to a newer gVisor release, so the old pinned
-# hash (9844ad24…) no longer matched and the integrity check aborted boot. Updated
-# to the current latest's verified sha512 (matches gVisor's published runsc.sha512).
-# TODO: pin a dated/immutable release URL instead of 'latest' so this can't recur.
+# NOTE 2026-06-25: 'latest' rolled AGAIN (recurrence of the 2026-06-12 break) — the
+# pinned 8ecbf845… no longer matched gVisor's published runsc.sha512, the integrity
+# check aborted boot, and hermes-staging wedged on EVERY reboot (incl. resize/redeploy)
+# until diagnosed via `phala cvms serial-logs`. Bumped to the current latest's verified
+# sha512. REAL FIX still pending: pin a dated/immutable release URL instead of 'latest'
+# so an upstream roll can never wedge boot again.
 RUNSC_URL="https://storage.googleapis.com/gvisor/releases/release/latest/x86_64/runsc"
-RUNSC_SHA512="8ecbf845e50880ab65573153756aea01da2823d05a61bce23c6c24f4446d064ab5a253e7ee6a8b619c5934c373ea74487c7c2ab2754dfb1e0b27860c6e0d2014"
+RUNSC_SHA512="6df95d09363dbd9ee5d5c889c1549b457e1783b039ff60a8f9f16f8c94c774a2ca2eef5b1c370e36b863f6b0407b53ba3c69051c6ef051253843dabf89a6de4e"
 INSTALL_DIR="/dstack/persistent/bin"
 
 verify_sha512() {


### PR DESCRIPTION
Bumps the pinned gVisor `runsc` sha512 from the stale `8ecb…` to the current published `6df9…`. The stale pin made the dstack prelaunch integrity check abort boot, wedging hermes-staging on every reboot until diagnosed via `phala cvms serial-logs`. Live-verified on the CVM (boot completes). Follow-up still open: pin a dated/immutable release URL instead of `latest` so this can't recur.

🤖 Generated with [Claude Code](https://claude.com/claude-code)