### PR TITLE
Scoped, revocable per-client API tokens (#18)

### DIFF
--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -19,6 +19,7 @@ from .deploy import deploy, teardown, promote
 from . import runtimes as runtimes_mod
 from .runtimes import RuntimeManager
 from .tunnel import TunnelStore, TunnelResponse
+from .tokens import DEFAULT_TTL, TokenStore
 from . import secp
 
 log = logging.getLogger(__name__)
@@ -55,13 +56,15 @@ MIME_TYPES = {
 class Ingress:
     def __init__(self, store: ProjectStore, docker: DockerClient,
                  audit_manager: AuditLogManager, tracker: ContainerTracker,
-                 rtm: RuntimeManager, tunnel_store: TunnelStore):
+                 rtm: RuntimeManager, tunnel_store: TunnelStore,
+                 token_store: TokenStore):
         self.store = store
         self.docker = docker
         self.audit_manager = audit_manager
         self.tracker = tracker
         self.rtm = rtm
         self.tunnel_store = tunnel_store
+        self.token_store = token_store
         self.port_map: dict[int, str] = {}  # port -> project_name
 
     async def handle(self, request: web.Request) -> web.Response:
@@ -464,15 +467,20 @@ class Ingress:
             log.error("WebSocket proxy error: %s", e)
             return web.json_response({"error": "websocket proxy failed"}, status=500)
 
-    def _check_auth(self, request: web.Request) -> web.Response | None:
+    def _check_auth(self, request: web.Request, api_path: str,
+                    owner_only: bool = False) -> web.Response | None:
         if not API_TOKEN:
             return None
         auth = request.headers.get("Authorization", "")
         if not auth.startswith("Bearer "):
             return web.json_response({"error": "missing token"}, status=401)
         token = auth[7:]
-        if not hmac.compare_digest(token, API_TOKEN):
-            return web.json_response({"error": "invalid token"}, status=403)
+        if hmac.compare_digest(token, API_TOKEN):
+            return None
+        if owner_only:
+            return web.json_response({"error": "owner token required"}, status=403)
+        if not self.token_store.authenticate(token, api_path):
+            return web.json_response({"error": "invalid token or scope"}, status=403)
         return None
 
     def _substrate_info(self) -> dict:
@@ -538,9 +546,19 @@ class Ingress:
                     resp.headers["Access-Control-Allow-Origin"] = "*"
                     return resp
 
-        denied = self._check_auth(request)
+        owner_only = path == "tokens" or path.startswith("tokens/")
+        denied = self._check_auth(request, path, owner_only=owner_only)
         if denied:
             return denied
+
+        # Scoped token API endpoints
+        if path == "tokens" and method == "POST":
+            return await self._api_create_token(request)
+        if path == "tokens" and method == "GET":
+            return await self._api_list_tokens()
+        if path.startswith("tokens/") and method == "DELETE":
+            token_id = path.split("/")[1]
+            return await self._api_revoke_token(token_id)
 
         # Tunnel API endpoints
         if path == "tunnels" and method == "POST":
@@ -838,3 +856,30 @@ class Ingress:
         if self.tunnel_store.delete(tunnel_id):
             return web.json_response({"ok": True})
         return web.json_response({"error": "tunnel not found"}, status=404)
+
+    async def _api_create_token(self, request: web.Request) -> web.Response:
+        try:
+            data = await request.json()
+            scope = data.get("scope", "")
+            ttl = data.get("ttl", DEFAULT_TTL)
+            try:
+                ttl = int(ttl)
+            except (TypeError, ValueError):
+                return web.json_response({"error": "ttl must be an integer"}, status=400)
+            token, bearer = self.token_store.create(scope, ttl)
+            body = token.public()
+            body["token"] = bearer
+            return web.json_response(body, status=201)
+        except ValueError as e:
+            return web.json_response({"error": str(e)}, status=400)
+        except Exception as e:
+            log.error("Error creating scoped API token: %s", e)
+            return web.json_response({"error": "internal server error"}, status=500)
+
+    async def _api_list_tokens(self) -> web.Response:
+        return web.json_response([t.public() for t in self.token_store.list()])
+
+    async def _api_revoke_token(self, token_id: str) -> web.Response:
+        if self.token_store.revoke(token_id):
+            return web.json_response({"ok": True})
+        return web.json_response({"error": "token not found"}, status=404)

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -15,6 +15,7 @@ from .docker_client import DockerClient
 from .projects import ProjectStore
 from .runtimes import RuntimeManager
 from .tunnel import TunnelStore
+from .tokens import TokenStore
 from . import ingress as ingress_mod
 from .ingress import Ingress
 
@@ -30,6 +31,7 @@ DSTACK_SOCK = os.environ.get("DSTACK_SOCKET", "/var/run/dstack.sock")
 DATA_DIR = os.environ.get("DAEMON_DATA_DIR", "/var/lib/tee-daemon/projects")
 AUDIT_DIR = os.environ.get("DAEMON_AUDIT_DIR", "/var/lib/tee-daemon/audit")
 TUNNEL_DIR = os.environ.get("DAEMON_TUNNEL_DIR", "/var/lib/tee-daemon/tunnels")
+TOKEN_DIR = os.environ.get("DAEMON_TOKEN_DIR", "/var/lib/tee-daemon/tokens")
 INGRESS_PORT = int(os.environ.get("INGRESS_PORT", "8080"))
 
 
@@ -46,6 +48,7 @@ async def start():
     store = ProjectStore(DATA_DIR)
     rtm = RuntimeManager(docker, store, tracker)
     tunnel_store = TunnelStore(TUNNEL_DIR)
+    token_store = TokenStore(TOKEN_DIR)
 
     # Docker socket proxy (existing)
     docker_proxy = DockerProxy(DOCKER_SOCK, tracker, audit_manager)
@@ -102,8 +105,12 @@ async def start():
     tunnel_store.recover()
     log.info("Recovered %d active tunnels", len(tunnel_store.list()))
 
+    # Recovery: restore scoped API tokens from disk
+    token_store.recover()
+    log.info("Recovered %d scoped API tokens", len(token_store.list()))
+
     # Ingress + API on TCP port(s)
-    ing = Ingress(store, docker, audit_manager, tracker, rtm, tunnel_store)
+    ing = Ingress(store, docker, audit_manager, tracker, rtm, tunnel_store, token_store)
 
     # Check for port conflicts. The default ingress port (INGRESS_PORT) is
     # path-based-routing-only — multiple projects may "request" it, but they
@@ -158,13 +165,14 @@ async def start():
 
     log.info("tee-daemon running")
 
-    # Background task: cleanup expired tunnels
-    async def cleanup_expired_tunnels():
+    # Background task: cleanup expired short-lived grants
+    async def cleanup_expired_grants():
         while True:
             await asyncio.sleep(60)  # Check every minute
             tunnel_store.cleanup_expired()
+            token_store.cleanup_expired()
 
-    cleanup_task = asyncio.create_task(cleanup_expired_tunnels())
+    cleanup_task = asyncio.create_task(cleanup_expired_grants())
 
     stop = asyncio.Event()
     for sig_name in ("SIGINT", "SIGTERM"):

--- a/proxy/tokens.py
+++ b/proxy/tokens.py
@@ -1,0 +1,186 @@
+"""Scoped bearer token management for the daemon API."""
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import re
+import secrets
+from dataclasses import asdict, dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+MAX_TTL = 86400
+DEFAULT_TTL = 3600
+NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
+API_PREFIXES = {
+    "audit",
+    "attest",
+    "projects",
+    "routes",
+    "substrate",
+    "tunnels",
+    "tokens",
+    "verification",
+}
+
+
+@dataclass
+class ApiToken:
+    id: str
+    scope: str
+    ttl: int
+    created_at: str
+    expires_at: str
+    revoked: bool
+    secret_hash: str
+
+    def is_expired(self) -> bool:
+        try:
+            expires = datetime.fromisoformat(self.expires_at.replace("Z", "+00:00"))
+            return datetime.now(timezone.utc) >= expires
+        except Exception:
+            return True
+
+    def public(self) -> dict:
+        data = asdict(self)
+        data.pop("secret_hash", None)
+        return data
+
+
+class TokenStore:
+    def __init__(self, base_dir: str):
+        self.base_dir = base_dir
+        self._tokens: dict[str, ApiToken] = {}
+        os.makedirs(base_dir, exist_ok=True)
+
+    def _token_path(self, token_id: str) -> str:
+        return os.path.join(self.base_dir, f"{token_id}.json")
+
+    def create(self, scope: str, ttl: int) -> tuple[ApiToken, str]:
+        if ttl <= 0 or ttl > MAX_TTL:
+            raise ValueError(f"TTL must be between 1 and {MAX_TTL} seconds")
+
+        normalized_scope = normalize_scope(scope)
+        if not normalized_scope:
+            raise ValueError(f"Invalid scope: {scope!r}")
+
+        token_id = f"tok-{secrets.token_urlsafe(8)}"
+        secret = secrets.token_urlsafe(32)
+        bearer = f"tdt_{token_id}_{secret}"
+        now = datetime.now(timezone.utc)
+        token = ApiToken(
+            id=token_id,
+            scope=normalized_scope,
+            ttl=ttl,
+            created_at=now.isoformat(),
+            expires_at=(now + timedelta(seconds=ttl)).isoformat(),
+            revoked=False,
+            secret_hash=_hash_secret(bearer),
+        )
+        self._tokens[token_id] = token
+        self._save_token(token)
+        log.info("Created scoped API token %s scope=%s expires=%s",
+                 token_id, normalized_scope, token.expires_at)
+        return token, bearer
+
+    def authenticate(self, bearer: str, api_path: str) -> Optional[ApiToken]:
+        for token in list(self._tokens.values()):
+            if token.is_expired():
+                self.delete(token.id)
+                continue
+            if token.revoked:
+                continue
+            if hmac.compare_digest(token.secret_hash, _hash_secret(bearer)):
+                return token if scope_allows(token.scope, api_path) else None
+        return None
+
+    def list(self) -> list[ApiToken]:
+        active = []
+        for token in list(self._tokens.values()):
+            if token.is_expired():
+                self.delete(token.id)
+            else:
+                active.append(token)
+        return sorted(active, key=lambda t: t.created_at)
+
+    def revoke(self, token_id: str) -> bool:
+        token = self._tokens.get(token_id)
+        if not token:
+            return False
+        token.revoked = True
+        self._save_token(token)
+        log.info("Revoked scoped API token %s", token_id)
+        return True
+
+    def delete(self, token_id: str) -> bool:
+        token_path = self._token_path(token_id)
+        if os.path.exists(token_path):
+            os.unlink(token_path)
+        if token_id in self._tokens:
+            del self._tokens[token_id]
+            return True
+        return False
+
+    def cleanup_expired(self):
+        for token_id in [tid for tid, token in self._tokens.items() if token.is_expired()]:
+            self.delete(token_id)
+
+    def recover(self):
+        if not os.path.exists(self.base_dir):
+            return
+
+        for fname in os.listdir(self.base_dir):
+            if not fname.endswith(".json"):
+                continue
+            token_id = fname[:-5]
+            token_path = os.path.join(self.base_dir, fname)
+            try:
+                with open(token_path, "r") as f:
+                    data = json.load(f)
+                token = ApiToken(**data)
+                if token.is_expired():
+                    os.unlink(token_path)
+                    continue
+                self._tokens[token_id] = token
+                log.info("Recovered scoped API token %s", token_id)
+            except Exception as e:
+                log.warning("Failed to recover scoped API token %s: %s", token_id, e)
+                if os.path.exists(token_path):
+                    os.unlink(token_path)
+
+    def _save_token(self, token: ApiToken):
+        with open(self._token_path(token.id), "w") as f:
+            json.dump(asdict(token), f, indent=2)
+
+
+def normalize_scope(scope: str) -> str:
+    if not isinstance(scope, str):
+        return ""
+    scope = scope.strip().strip("/")
+    if not scope:
+        return ""
+
+    parts = scope.split("/")
+    if len(parts) == 1 and NAME_RE.fullmatch(parts[0]) and parts[0] not in API_PREFIXES:
+        return f"projects/{parts[0]}"
+    if parts[0] not in API_PREFIXES:
+        return ""
+    if any(not part for part in parts):
+        return ""
+    return scope
+
+
+def scope_allows(scope: str, api_path: str) -> bool:
+    normalized = normalize_scope(scope)
+    path = api_path.strip("/")
+    if not normalized:
+        return False
+    return path == normalized or path.startswith(normalized + "/")
+
+
+def _hash_secret(secret: str) -> str:
+    return hashlib.sha256(secret.encode()).hexdigest()

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -72,6 +72,7 @@ def start_daemon():
         "DAEMON_DATA_DIR": os.path.join(tmpdir, "projects"),
         "DAEMON_AUDIT_DIR": os.path.join(tmpdir, "audit"),
         "DAEMON_TUNNEL_DIR": os.path.join(tmpdir, "tunnels"),
+        "DAEMON_TOKEN_DIR": os.path.join(tmpdir, "tokens"),
         "PROXY_SOCKET_DIR": os.path.join(tmpdir, "proxy"),
         "DOCKER_SOCKET": "/var/run/docker.sock",
         "DSTACK_SOCKET": "/nonexistent",
@@ -137,6 +138,41 @@ def test_ingress_static():
     assert resp.status_code == 200
     assert "Hello from TEE" in resp.text
     print("  Content verified")
+
+
+def test_scoped_tokens():
+    print("\n--- Test: scoped, revocable API tokens ---")
+    resp = api_post("/tokens", json={"scope": "projects/test-static", "ttl": 600})
+    assert resp.status_code == 201, f"token create failed: {resp.status_code} {resp.text}"
+    body = resp.json()
+    token_id = body["id"]
+    scoped_auth = {"Authorization": f"Bearer {body['token']}"}
+    assert body["scope"] == "projects/test-static"
+    assert body["revoked"] is False
+
+    resp = requests.get(f"{API}/projects/test-static", headers=scoped_auth)
+    assert resp.status_code == 200, f"scoped token should read project: {resp.status_code} {resp.text}"
+
+    resp = requests.get(f"{API}/routes", headers=scoped_auth)
+    assert resp.status_code == 403, f"scoped token must not read routes: {resp.status_code} {resp.text}"
+
+    resp = requests.get(f"{API}/tokens", headers=scoped_auth)
+    assert resp.status_code == 403, "scoped token must not access token admin API"
+
+    resp = api_get("/tokens")
+    assert resp.status_code == 200
+    tokens = resp.json()
+    created = [t for t in tokens if t["id"] == token_id]
+    assert created and "token" not in created[0] and "secret_hash" not in created[0]
+
+    resp = api_delete(f"/tokens/{token_id}")
+    assert resp.status_code == 200
+    resp = requests.get(f"{API}/projects/test-static", headers=scoped_auth)
+    assert resp.status_code == 403, "revoked token must fail closed immediately"
+
+    resp = api_get("/routes")
+    assert resp.status_code == 200, "owner token keeps full access"
+    print("  scoped allow/deny, revoke, owner compatibility ✓")
 
 
 def test_git_blocked():
@@ -704,6 +740,7 @@ def main():
         test_auth()
         test_deploy_static()
         test_ingress_static()
+        test_scoped_tokens()
         test_git_blocked()
         test_playwright_static()
         test_deploy_deno()


### PR DESCRIPTION
Autonomous staging worker (#18). New proxy/tokens.py: JSON-backed scoped tokens, TTL recovery, owner-only admin endpoints, endpoint-prefix authorization, immediate revoke; owner token keeps full access. Local suite + e2e green, independently re-verified by the integrator. Targets `staging`.

🤖 autonomous Paseo batch