### PR TITLE
Fix isolated Deno env passthrough

### DIFF
--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -278,7 +278,7 @@ async def deploy(store: ProjectStore, docker: DockerClient, audit_manager,
         env=env_vars, deployed_at=datetime.now(timezone.utc).isoformat(),
         source=source, ref=ref, commit_sha=commit_sha, tree_hash=tree_hash,
         listen=listen_config, isolation=isolation,
-        env_passthrough=manifest.get("env_passthrough", []) or [],
+        env_passthrough=manifest.get("env_passthrough") or repo_manifest.get("env_passthrough", []) or [],
         oci_runtime=manifest.get("oci_runtime", ""),
     )
     store.save(project)

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -77,6 +77,7 @@ def start_daemon():
         "DOCKER_SOCKET": "/var/run/docker.sock",
         "DSTACK_SOCKET": "/nonexistent",
         "TEE_DAEMON_TOKEN": TEST_TOKEN,
+        "FOO": "isolated-deno-passthrough",
     }
     daemon_proc = subprocess.Popen(
         [sys.executable, "-m", "proxy.main"],
@@ -435,6 +436,37 @@ def test_env_passthrough():
     api_delete("/projects/test-passthru")
 
 
+def test_isolated_deno_env_passthrough():
+    print("\n--- Test: isolated deno env_passthrough ---")
+    repo = create_test_repo("test-iso-passthru", {
+        "project.json": json.dumps({"runtime": "deno", "isolation": "container",
+                                    "listen": {"port": 8080, "protocol": "http"},
+                                    "env_passthrough": ["FOO"]}).encode(),
+        "server.ts": b"""
+export default (_req: Request, ctx: {env: Record<string,string>}) => {
+  return new Response(JSON.stringify({foo: ctx.env.FOO || ""}),
+    {headers: {"content-type": "application/json"}});
+};
+""",
+    })
+    resp = api_post("/projects", json={"name": "test-iso-passthru", "source": repo})
+    assert resp.status_code == 201, f"Deploy failed: {resp.text}"
+    body = resp.json()
+    assert body["env_passthrough"] == ["FOO"]
+    assert "isolated-deno-passthrough" not in json.dumps(body), \
+        "passthrough value leaked into project json"
+
+    for _ in range(20):
+        r = requests.get(f"{INGRESS}/test-iso-passthru/")
+        if r.status_code == 200:
+            break
+        time.sleep(0.5)
+    assert r.status_code == 200, r.text
+    assert r.json() == {"foo": "isolated-deno-passthrough"}, r.text
+    print("  Handler saw FOO from daemon env via ctx.env ✓")
+    api_delete("/projects/test-iso-passthru")
+
+
 def test_per_project_network_isolation():
     print("\n--- Test: image-runtime tenants on separate networks ---")
     for n in ("net-a", "net-b"):
@@ -762,7 +794,7 @@ def test_export_import_pinned():
 
 def test_teardown():
     print("\n--- Test: teardown ---")
-    for name in ["test-static", "test-deno", "test-auto", "test-tarball", "test-image", "test-iso-a", "test-iso-b", "test-passthru", "test-redeploy-img", "net-a", "net-b", "data-iso"]:
+    for name in ["test-static", "test-deno", "test-auto", "test-tarball", "test-image", "test-iso-a", "test-iso-b", "test-passthru", "test-iso-passthru", "test-redeploy-img", "net-a", "net-b", "data-iso"]:
         resp = api_delete(f"/projects/{name}")
         if resp.status_code == 200:
             print(f"  Torn down: {name}")
@@ -791,6 +823,7 @@ def main():
         test_per_project_network_isolation()
         test_isolated_per_project_data_volume()
         test_env_passthrough()
+        test_isolated_deno_env_passthrough()
         test_image_redeploy()
         test_substrate_endpoint()
         test_autodetect()


### PR DESCRIPTION
**What it does**
Allows normal git-deployed Deno/Bun projects to inherit `env_passthrough` from their repo `project.json`, then passes those daemon env values into isolated container handlers through `ctx.env`. Adds a regression test for an `isolation: container` Deno app reading `FOO`.

**What you get by merging**
Oauth3-style isolated Deno apps can receive daemon-owned secrets such as `OWNER_SECRET`/`SEAL_KEY` without storing secret values in project JSON.

**Risk / what to watch**
Low. This only changes manifest merging for non-image deploys; API request values still take precedence when supplied. Watch for projects that relied on repo-declared `env_passthrough` being ignored.

**Verification**
`test_daemon.py` passed. backend-only — no visual evidence.

<details>
<summary>Diff / log detail</summary>

- `proxy/deploy.py`: merge `env_passthrough` from repo manifests for normal runtime deploys.
- `test_daemon.py`: adds isolated Deno passthrough E2E where handler reads `FOO` from `ctx.env` and verifies the value is not stored in project JSON.
- Log: `/home/amiller/paseo-batch/out/41/test.log`

</details>