### PR TITLE
Add GET /_api/version endpoint (daemon version + git commit)

### DIFF
--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -495,6 +495,20 @@ class Ingress:
             "networks": [runtimes_mod.NETWORK_DEV, runtimes_mod.NETWORK_ATTESTED],
         }
 
+    def _api_version(self) -> dict:
+        """Return daemon version and git commit."""
+        import subprocess
+        commit = "unknown"
+        try:
+            commit = subprocess.check_output(
+                ["git", "rev-parse", "--short", "HEAD"],
+                cwd=os.path.dirname(os.path.dirname(__file__)),
+                stderr=subprocess.DEVNULL
+            ).decode().strip()
+        except Exception:
+            pass
+        return {"version": "dev", "commit": commit}
+
     def _public_attested_path(self, path: str) -> str | None:
         """RFC 0015: return project name if `path` is a public verifier endpoint."""
         parts = path.split("/")
@@ -519,6 +533,11 @@ class Ingress:
                 "Access-Control-Allow-Headers": "*",
                 "Access-Control-Max-Age": "86400",
             })
+
+        if method == "GET" and path == "version":
+            resp = web.json_response(self._api_version())
+            resp.headers["Access-Control-Allow-Origin"] = "*"
+            return resp
 
         if method == "GET" and path == "substrate":
             resp = web.json_response(self._substrate_info())

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -120,6 +120,18 @@ def test_auth():
     print("  Auth: 401/403/200/200 ✓")
 
 
+def test_version():
+    print("\n--- Test: version endpoint ---")
+    resp = requests.get(f"{API}/version")
+    assert resp.status_code == 200, f"version endpoint failed: {resp.status_code} {resp.text}"
+    data = resp.json()
+    assert "version" in data, f"version field missing: {data}"
+    assert "commit" in data, f"commit field missing: {data}"
+    assert isinstance(data["version"], str)
+    assert isinstance(data["commit"], str)
+    print(f"  Version: {data['version']} commit: {data['commit']} ✓")
+
+
 def test_deploy_static():
     print("\n--- Test: deploy static from git ---")
     repo = create_test_repo("test-static", {
@@ -808,6 +820,7 @@ def main():
     start_daemon()
     try:
         test_auth()
+        test_version()
         test_deploy_static()
         test_ingress_static()
         test_scoped_tokens()


### PR DESCRIPTION
## What it does
Adds a public \`GET /_api/version\` endpoint to \`proxy/ingress.py\` that returns JSON with the daemon version and git commit SHA.

## What you get by merging
Clients can programmatically query the running daemon to identify its version (currently \`\"dev\"\` placeholder) and git commit hash (short SHA). Useful for diagnostics and version verification.

## Risk / what to watch
Minimal. The endpoint is public (no auth required) and only returns static version info. No fallbacks — if git is unavailable, commit returns \`\"unknown\"\`.

## Verification
Backend-only — no visual evidence. \`test_daemon.py\` passes with new \`test_version()\` asserting 200 + required fields.

<details>
<summary>Diff stats + raw log</summary>

\`\`\`
 proxy/ingress.py | 19 +++++++++++++++++++
 test_daemon.py   | 13 +++++++++++++
 2 files changed, 32 insertions(+)
\`\`\`

See full log at: \`~/paseo-batch/out/44/test.log\`
</details>