### PR TITLE
Attested container capabilities (caps ⟹ attested)

### DIFF
--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -177,6 +177,13 @@ async def deploy(store: ProjectStore, docker: DockerClient, audit_manager,
     mode = manifest.get("mode") or repo_manifest.get("mode", "dev")
     if mode not in ("dev", "attested"):
         mode = "dev"
+    # Elevated caps are honored ONLY for attested projects, so the grant is always on
+    # the verifiable surface. Prefer the repo-committed manifest so tree_hash commits to
+    # them (a verifier fetching the source commit can confirm what was granted).
+    cap_add = repo_manifest.get("cap_add") or manifest.get("cap_add", []) or []
+    devices = repo_manifest.get("devices") or manifest.get("devices", []) or []
+    if (cap_add or devices) and mode != "attested":
+        raise ValueError("cap_add/devices require mode=attested")
     env_vars = {**repo_manifest.get("env", {}), **manifest.get("env", {})}
     isolation = manifest.get("isolation") or repo_manifest.get("isolation", "shared")
     if isolation not in ("shared", "container"):
@@ -229,6 +236,7 @@ async def deploy(store: ProjectStore, docker: DockerClient, audit_manager,
         listen=listen_config, isolation=isolation,
         env_passthrough=manifest.get("env_passthrough", []) or [],
         oci_runtime=manifest.get("oci_runtime", ""),
+        cap_add=cap_add, devices=devices,
     )
     store.save(project)
 
@@ -247,7 +255,8 @@ async def deploy(store: ProjectStore, docker: DockerClient, audit_manager,
         await audit.record(AuditEntry(
             timestamp=time.time(), action="deploy", image=image, image_digest=digest,
             detail=json.dumps({"name": name, "source": source, "ref": ref,
-                               "commit": commit_sha, "tree_hash": tree_hash})))
+                               "commit": commit_sha, "tree_hash": tree_hash,
+                               "cap_add": cap_add, "devices": devices})))
 
     log.info("Deployed %s from %s@%s (%s)", name, source, ref or "HEAD", commit_sha[:12])
     return project
@@ -266,6 +275,12 @@ async def _deploy_image(store: ProjectStore, audit_manager,
     mode = manifest.get("mode", "dev")
     if mode not in ("dev", "attested"):
         mode = "dev"
+    # Image projects have no source tree, so the caps are bound by the append-only audit
+    # detail + the image @sha256 digest (immutable code), not tree_hash. Still attested-only.
+    cap_add = manifest.get("cap_add", []) or []
+    devices = manifest.get("devices", []) or []
+    if (cap_add or devices) and mode != "attested":
+        raise ValueError("cap_add/devices require mode=attested")
     env_vars = manifest.get("env", {})
 
     listen_manifest = manifest.get("listen") or {}
@@ -290,7 +305,7 @@ async def _deploy_image(store: ProjectStore, audit_manager,
         commit_sha=manifest.get("commit_sha", ""), tree_hash=manifest.get("tree_hash", ""),
         image=image, image_port=image_port, volumes=volumes,
         env_passthrough=env_passthrough, listen=listen_config,
-        oci_runtime=oci_runtime,
+        oci_runtime=oci_runtime, cap_add=cap_add, devices=devices,
     )
     store.save(project)
 
@@ -302,7 +317,8 @@ async def _deploy_image(store: ProjectStore, audit_manager,
         audit = audit_manager.get_audit_log(name)
         await audit.record(AuditEntry(
             timestamp=time.time(), action="deploy", image=image, image_digest=digest,
-            detail=json.dumps({"name": name, "image": image, "image_port": image_port})))
+            detail=json.dumps({"name": name, "image": image, "image_port": image_port,
+                               "image_digest": digest, "cap_add": cap_add, "devices": devices})))
 
     log.info("Deployed image project %s from %s (digest %s)", name, image, digest[:19])
     return project

--- a/proxy/docker_client.py
+++ b/proxy/docker_client.py
@@ -31,12 +31,20 @@ class DockerClient:
                                binds: list[str], labels: dict, network: str,
                                env: list[str] | None = None,
                                runtime: str = "",
-                               restart_policy: dict | None = None) -> str:
+                               restart_policy: dict | None = None,
+                               cap_add: list[str] | None = None,
+                               devices: list[str] | None = None) -> str:
         host_config: dict = {"Binds": binds}
         if runtime:
             host_config["Runtime"] = runtime
         if restart_policy:
             host_config["RestartPolicy"] = restart_policy
+        if cap_add:
+            host_config["CapAdd"] = cap_add
+        if devices:
+            host_config["Devices"] = [
+                {"PathOnHost": d, "PathInContainer": d, "CgroupPermissions": "rwm"}
+                for d in devices]
         body = {
             "Image": image,
             "Cmd": cmd or None,

--- a/proxy/docker_proxy.py
+++ b/proxy/docker_proxy.py
@@ -153,6 +153,11 @@ class DockerProxy:
         # Replace whatever network the client requested with the appropriate network
         host_config = body.get("HostConfig", {})
         host_config.pop("NetworkMode", None)
+        # Elevated capabilities are NOT grantable via the tenant socket — the only path
+        # is the daemon's own gated create (caps ⟹ attested, surfaced in the manifest).
+        host_config.pop("CapAdd", None)
+        host_config.pop("Devices", None)
+        host_config.pop("Privileged", None)
         body["HostConfig"] = host_config
 
         body["NetworkingConfig"] = {"EndpointsConfig": {network: {}}}

--- a/proxy/projects.py
+++ b/proxy/projects.py
@@ -36,6 +36,11 @@ class Project:
     isolation: str = "shared"
     env_passthrough: List[str] = field(default_factory=list)
     oci_runtime: str = ""  # per-project OCI runtime, e.g. "runsc" (gVisor); falls back to CONTAINER_RUNTIME
+    # Elevated container capabilities — honored ONLY for mode=="attested" projects (see
+    # deploy gate), so the grant is always on the verifiable attested surface. Used e.g.
+    # for an in-container OpenVPN sidecar (CAP_NET_ADMIN + /dev/net/tun).
+    cap_add: List[str] = field(default_factory=list)
+    devices: List[str] = field(default_factory=list)
 
     def __post_init__(self):
         if self.env is None:

--- a/proxy/runtimes.py
+++ b/proxy/runtimes.py
@@ -492,9 +492,12 @@ class RuntimeManager:
             json.dumps(env),
         ]
 
+        caps = project.cap_add if project.mode == "attested" else []
+        devs = project.devices if project.mode == "attested" else []
         cid = await self.docker.create_container(
             cname, image, cmd, binds, labels, network,
-            runtime=(project.oci_runtime or CONTAINER_RUNTIME))
+            runtime=(project.oci_runtime or CONTAINER_RUNTIME),
+            cap_add=caps, devices=devs)
         await self.docker.start(cid)
         self.tracker.add(cid)
         ip = await self.docker.container_ip(cid, network)
@@ -543,10 +546,13 @@ class RuntimeManager:
             if val is not None:
                 env.append(f"{key}={val}")
         runtime = project.oci_runtime or CONTAINER_RUNTIME
+        caps = project.cap_add if project.mode == "attested" else []
+        devs = project.devices if project.mode == "attested" else []
         cid = await self.docker.create_container(
             cname, project.image, [], binds, labels, network,
             env=env, runtime=runtime,
-            restart_policy=IMAGE_APP_RESTART_POLICY)
+            restart_policy=IMAGE_APP_RESTART_POLICY,
+            cap_add=caps, devices=devs)
         await self.docker.start(cid)
         self.tracker.add(cid)
         ip = await self.docker.container_ip(cid, network)

--- a/rfcs/0025-attested-capabilities.md
+++ b/rfcs/0025-attested-capabilities.md
@@ -1,0 +1,92 @@
+# RFC 0025: Attested container capabilities
+
+**Status**: Draft
+
+## Summary
+
+Let a project request elevated Linux capabilities (`CAP_NET_ADMIN`) and device
+access (`/dev/net/tun`) on its container — but **only** when the project is
+`mode:"attested"`, so the elevated grant is always on the verifiable attested
+surface. The motivating use case: run an OpenVPN-TCP→SOCKS sidecar *inside* a
+single image project (Phala blocks UDP, so WireGuard/userspace is out; OpenVPN
+needs a TUN device + `NET_ADMIN`, which the daemon otherwise strips).
+
+The rule that makes this safe: **caps ⟹ attested**. Elevation forces
+transparency — there is no reachable state where a project holds `NET_ADMIN`
+that a verifier cannot see.
+
+## Problem
+
+`create_container` (`proxy/docker_client.py`) intentionally exposes no
+`CapAdd`/`Devices`/`Privileged`, and the tenant docker-proxy strips
+`NetworkMode`. So a kernel-TUN VPN cannot run as a tenant. The only options were
+a standalone (non-daemon) CVM or a blanket capability grant — the latter being
+*invisible privilege*: a tenant silently gets `NET_ADMIN` and you must trust the
+operator. We want the privilege to be a **legible, verifiable claim** instead,
+in the spirit of the capability-statement work (consumer-checkable evidence).
+
+## Design
+
+1. **Manifest fields.** `cap_add: [str]`, `devices: [str]` on the `Project`
+   model. They serialize via `asdict()` into the stored manifest and the
+   RFC-0015 public verification read, so a verifier reading
+   `/_api/projects/<name>` sees exactly what was granted.
+
+2. **The gate: caps ⟹ attested.** `deploy()` / `_deploy_image()` reject
+   `cap_add`/`devices` unless `mode == "attested"`. `start_isolated()` /
+   `start_image()` re-check at apply time (belt-and-suspenders): caps are passed
+   to Docker only for attested projects. A dev-mode project — which is hidden
+   from the verification endpoint — can never hold caps.
+
+3. **Binding the grant to the attestation.**
+   - *Source projects (git/deno):* caps are read preferentially from the
+     **repo-committed `project.json`**, which is inside the `files/` tree, so
+     `tree_hash`/`git_tree_sha` commits to them. A verifier who fetches the
+     source commit confirms the declared caps.
+   - *Image projects:* there is no source tree, so the grant is bound by the
+     **append-only audit `detail`** (recorded at deploy, inside the TEE) plus the
+     pinned **`image@sha256` digest** (immutable code). The audit entry now
+     includes `cap_add`/`devices` and the image digest.
+
+4. **Defense in depth.** The tenant-facing docker-proxy also strips
+   `CapAdd`/`Devices`/`Privileged`, so the *only* path to caps is the daemon's
+   own gated create.
+
+## Blast radius
+
+`CAP_NET_ADMIN` is a per-network-namespace capability. Each project container
+runs in its own netns on its own bridge (`tee-proj-<name>-<mode>`). A
+NET_ADMIN tenant:
+
+- **Can** manage *its own* netns — bring up `tun0`, set routes/iptables (the VPN
+  use case). Confined to its namespace.
+- **Cannot** reconfigure the host netns or other projects' namespaces; it does
+  not grant host root.
+- Shares an L2 segment only with the daemon's own proxy endpoint *to this same
+  project* (the daemon attaches itself to the per-project bridge to proxy).
+- **Residual:** caps + `/dev/net/tun` enlarge the shared-host-kernel attack
+  surface (netlink/netfilter/tun). Namespace confinement holds for behavior, not
+  for a kernel CVE. This is the standard "VPN sidecar with NET_ADMIN" profile,
+  acceptable for an attested, source-visible tenant inside a TEE. Note `runsc`
+  (gVisor) may not support `/dev/net/tun`; a TUN tenant runs under `runc`/`sysbox`.
+
+## Manifest example
+
+```json
+{
+  "name": "brave-spi",
+  "runtime": "image",
+  "image": "ghcr.io/amiller/brave-vpn-spi@sha256:...",
+  "image_port": 3000,
+  "mode": "attested",
+  "cap_add": ["NET_ADMIN"],
+  "devices": ["/dev/net/tun"],
+  "env_passthrough": ["OPENVPN_USER", "OPENVPN_PASS", "OVPN_CONFIG_BASE64"]
+}
+```
+
+## Out of scope
+
+Multi-container projects and a built-in VPN/egress adapter (RFC 0002's future
+work). This RFC is the minimal change that lets a single image project carry its
+own VPN, with the grant made verifiable rather than ambient.

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -131,6 +131,27 @@ def test_deploy_static():
     print(f"  Deployed: commit={project['commit_sha'][:12]} tree={project['tree_hash'][:12]}")
 
 
+def test_caps_require_attested():
+    print("\n--- Test: cap_add/devices require mode=attested ---")
+    repo = create_test_repo("test-caps", {
+        "index.html": b"<html><body>caps</body></html>",
+    })
+    # dev mode (default) + caps => rejected (caps must be on the attested surface)
+    resp = api_post("/projects", json={"name": "test-caps", "source": repo,
+                                       "runtime": "static", "cap_add": ["NET_ADMIN"]})
+    assert resp.status_code >= 400, f"dev-mode caps should be rejected, got {resp.status_code}"
+    print(f"  dev-mode + caps rejected ({resp.status_code}) ✓")
+    # attested mode + caps => accepted, surfaced on the project for verifiers
+    resp = api_post("/projects", json={"name": "test-caps", "source": repo,
+                                       "runtime": "static", "mode": "attested",
+                                       "cap_add": ["NET_ADMIN"], "devices": ["/dev/net/tun"]})
+    assert resp.status_code == 201, f"attested caps deploy failed: {resp.status_code} {resp.text}"
+    project = resp.json()
+    assert project["cap_add"] == ["NET_ADMIN"], project
+    assert project["devices"] == ["/dev/net/tun"], project
+    print("  attested + caps accepted and surfaced on project ✓")
+
+
 def test_ingress_static():
     print("\n--- Test: static serving ---")
     resp = requests.get(f"{INGRESS}/test-static/")
@@ -703,6 +724,7 @@ def main():
     try:
         test_auth()
         test_deploy_static()
+        test_caps_require_attested()
         test_ingress_static()
         test_git_blocked()
         test_playwright_static()


### PR DESCRIPTION
Closes #55.

Lets a project request `CAP_NET_ADMIN` + `/dev/net/tun`, honored **only** for `mode:"attested"` projects — so an elevated capability is always on the verifiable attested surface, never ambient.

### What & why
Phala blocks UDP (no WireGuard), and OpenVPN-TCP needs a TUN device + `NET_ADMIN` that the daemon strips. This blocked running a VPN-backed browser SPI as a tee-daemon project (forcing a standalone CVM). The fix makes the capability a **legible, verifiable claim** instead of invisible privilege.

### The rule: caps ⟹ attested
- `cap_add`/`devices` manifest fields → surface in the RFC-0015 verification read (`asdict(project)`).
- Gate in `deploy()`/`_deploy_image()`: reject caps unless `mode=="attested"`; re-checked at apply time in `start_isolated`/`start_image`.
- **Binding:** source projects via committed `project.json` in `tree_hash`; image projects via append-only audit `detail` + pinned `image@sha256`.
- Defense-in-depth: tenant docker-proxy strips `CapAdd`/`Devices`/`Privileged`, so the gated daemon create is the only path.

### Files
- `proxy/docker_client.py` — `CapAdd`/`Devices` in HostConfig
- `proxy/projects.py` — `cap_add`/`devices` fields
- `proxy/deploy.py` — parse + gate + audit-bind (both paths)
- `proxy/runtimes.py` — attested-gated apply
- `proxy/docker_proxy.py` — strip caps on tenant socket
- `test_daemon.py` — `test_caps_require_attested`
- `rfcs/0025-attested-capabilities.md` — design + blast radius

### Blast radius
`NET_ADMIN` is per-netns; confined to the project's own bridge — can't touch host or co-tenant namespaces. Residual: shared-kernel attack surface (tun/netlink/netfilter); namespace confinement holds for behavior, not a kernel CVE. Standard VPN-sidecar profile, inside a TEE.

### Testing
- Standalone-verified: `Project` round-trips `cap_add`/`devices` into `asdict()`; gate rejects dev-mode+caps, allows attested.
- Added `test_caps_require_attested` to the integration suite (CI).