### PR TITLE
Console: per-app 'next rung' trust-ladder hints

### DIFF
--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -26,6 +26,7 @@ from .tokens import DEFAULT_TTL, TokenStore
 from .broker import BrokerStore
 from . import secp
 from . import evidence
+from .ladder import ladder_hint
 
 log = logging.getLogger(__name__)
 
@@ -1164,6 +1165,7 @@ class Ingress:
             data["running"] = liveness["running"]
             data["container_id"] = liveness["container_id"]
             data["backend"] = liveness["backend"]
+            data["ladder"] = ladder_hint(data)
             # For attested projects, include public verification URL
             if project.mode == "attested":
                 # Get the scheme and host from the environment or request

--- a/proxy/ladder.py
+++ b/proxy/ladder.py
@@ -1,0 +1,68 @@
+"""RFC 0016 trust-ladder hint: one generated "next rung" line per project.
+
+Pure, offline classifier — no network, no LLM, no filesystem. It reads only the
+manifest fields that ProjectStore already persists, so the console can label each
+app's current standing and the single cheapest action to climb.
+"""
+
+# Ladder rungs (stable — do not renumber):
+#   0  unattestable    — no re-cloneable source (missing / NONE / tarball://)
+#   1  dev (private)    — re-cloneable source, not listed
+#   2  dev (public)     — re-cloneable source, listed
+#   3  attested         — promoted, tree hash pinned
+#   4  evidence-carrying (RFC 0021, next target above attested)
+#   5  curated          (RFC 0022, not yet built)
+
+
+def _recloneable(source: str) -> bool:
+    s = (source or "").strip()
+    return bool(s) and s.upper() != "NONE" and not s.startswith("tarball://")
+
+
+def ladder_hint(project: dict) -> dict:
+    """Classify a project's trust-ladder standing from its manifest.
+
+    `project` is the manifest dict (dataclasses.asdict of a Project). Returns
+    {"rung": int, "label": str, "next": str}. Rung numbering is documented above
+    and MUST stay stable. Rules are applied in order:
+
+      1. source missing / NONE / tarball://  -> rung 0
+      2. dev + re-cloneable + not public      -> rung 1
+      3. dev + public + source                -> rung 2
+      4. attested                             -> rung 3
+
+    Evidence-dir presence (rung 4) is not in the manifest, so an attested project
+    always gets the generic "next: evidence" hint rather than a filesystem probe.
+    """
+    name = project.get("name", "")
+    mode = project.get("mode", "dev")
+
+    if not _recloneable(project.get("source", "")):
+        return {
+            "rung": 0,
+            "label": "unattestable",
+            "next": "no re-cloneable source — adopt into a git repo "
+                    "(source+ref+commit) to become attestable",
+        }
+
+    if mode == "attested":
+        return {
+            "rung": 3,
+            "label": "attested",
+            "next": "attested — next: capability statement + evidence artifacts "
+                    "(RFC 0021); curated listing (RFC 0022) not yet built",
+        }
+
+    if not project.get("public", False):
+        return {
+            "rung": 1,
+            "label": "dev (private)",
+            "next": "set public:true to be listed, or promote to attested",
+        }
+
+    return {
+        "rung": 2,
+        "label": "dev (public)",
+        "next": f"promote to attested (POST /_api/projects/{name}/promote) — "
+                "pins the tree hash and opens the public verifier endpoints",
+    }

--- a/proxy/templates/console.html
+++ b/proxy/templates/console.html
@@ -160,6 +160,16 @@
             color: #718096;
             font-size: 0.85rem;
         }
+        .ladder-row td {
+            border-top: none;
+            padding-top: 0;
+            color: #a0aec0;
+            font-size: 0.8rem;
+        }
+        .ladder-rung {
+            font-weight: 600;
+            color: #718096;
+        }
         .empty {
             text-align: center;
             padding: 2rem;
@@ -348,6 +358,16 @@
                 ? `<span class="badge isolation">${project.isolation}</span>`
                 : '';
 
+            const ladder = project.ladder;
+            const ladderRow = ladder ? `
+                <tr class="ladder-row">
+                    <td></td>
+                    <td colspan="7">
+                        <span class="ladder-rung">${escapeHtml(ladder.label)}</span> · ${escapeHtml(ladder.next)}
+                    </td>
+                </tr>
+            ` : '';
+
             return `
                 <tr>
                     <td>
@@ -367,7 +387,14 @@
                         <div class="links">${links}</div>
                     </td>
                 </tr>
+                ${ladderRow}
             `;
+        }
+
+        function escapeHtml(s) {
+            const d = document.createElement('div');
+            d.textContent = s;
+            return d.innerHTML;
         }
 
         function formatTimeAgo(deployedAt) {

--- a/proxy/test_ladder.py
+++ b/proxy/test_ladder.py
@@ -1,0 +1,49 @@
+"""Unit tests for the pure ladder_hint classifier (no daemon, no docker)."""
+
+from .ladder import ladder_hint
+
+
+def _p(**kw):
+    base = {"name": "app", "mode": "dev", "public": False, "source": "https://github.com/o/r"}
+    base.update(kw)
+    return base
+
+
+def test_no_source_is_rung0():
+    h = ladder_hint(_p(source=""))
+    assert h["rung"] == 0
+    assert "adopt into a git repo" in h["next"]
+
+
+def test_none_source_is_rung0():
+    assert ladder_hint(_p(source="NONE"))["rung"] == 0
+
+
+def test_tarball_source_is_rung0():
+    assert ladder_hint(_p(source="tarball://local"))["rung"] == 0
+
+
+def test_dev_private_is_rung1():
+    h = ladder_hint(_p(public=False))
+    assert h["rung"] == 1
+    assert h["label"] == "dev (private)"
+    assert "set public:true" in h["next"]
+
+
+def test_dev_public_is_rung2():
+    h = ladder_hint(_p(name="myapp", public=True))
+    assert h["rung"] == 2
+    assert h["label"] == "dev (public)"
+    assert "POST /_api/projects/myapp/promote" in h["next"]
+
+
+def test_attested_is_rung3():
+    h = ladder_hint(_p(mode="attested", public=True))
+    assert h["rung"] == 3
+    assert h["label"] == "attested"
+    assert "RFC 0021" in h["next"] and "RFC 0022" in h["next"]
+
+
+def test_attested_without_source_is_still_rung0():
+    """Source rule takes precedence — an attested-but-unrecloneable app is stuck at 0."""
+    assert ladder_hint(_p(mode="attested", source="NONE"))["rung"] == 0


### PR DESCRIPTION
Adds a pure `ladder_hint(project)` classifier (proxy/ladder.py) that tags each app with its rung on the trust ladder (0 unattestable → 1 dev-private → 2 dev-public → 3 attested → 4/5 evidence/curated) and one actionable next step, computed from manifest fields only (no network, no LLM). Wired into GET /_api/status (each project gains a `ladder` field) and rendered as a muted per-row line in the console. Correctly pins the ~14 tarball/NONE apps at rung 0 ('no re-cloneable source — adopt into a git repo').

Turns RFC 0021's evidence-spend from an essay into a per-app checklist. 7 pure unit tests pass (proxy/test_ladder.py).

🤖 Generated with [Claude Code](https://claude.com/claude-code)