### PR TITLE
RFC 0029 Half A: declared operator_debug (attested-only door, disclosed)

### DIFF
--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -184,6 +184,11 @@ async def deploy(store: ProjectStore, docker: DockerClient, audit_manager,
     devices = repo_manifest.get("devices") or manifest.get("devices", []) or []
     if (cap_add or devices) and mode != "attested":
         raise ValueError("cap_add/devices require mode=attested")
+    # operator_debug is a measured boolean (RFC 0029); prefer the repo-committed value so
+    # tree_hash commits to it, mirroring cap_add. A declared door is full trust, attested-only.
+    operator_debug = bool(repo_manifest.get("operator_debug", manifest.get("operator_debug", False)))
+    if operator_debug and mode != "attested":
+        raise ValueError("operator_debug requires mode=attested")
     env_vars = {**repo_manifest.get("env", {}), **manifest.get("env", {})}
     isolation = manifest.get("isolation") or repo_manifest.get("isolation", "shared")
     if isolation not in ("shared", "container"):
@@ -237,7 +242,7 @@ async def deploy(store: ProjectStore, docker: DockerClient, audit_manager,
         listen=listen_config, isolation=isolation,
         env_passthrough=manifest.get("env_passthrough") or repo_manifest.get("env_passthrough", []) or [],
         oci_runtime=manifest.get("oci_runtime", ""),
-        cap_add=cap_add, devices=devices,
+        cap_add=cap_add, devices=devices, operator_debug=operator_debug,
     )
     store.save(project)
 
@@ -257,7 +262,8 @@ async def deploy(store: ProjectStore, docker: DockerClient, audit_manager,
         timestamp=time.time(), action="deploy", image=image, image_digest=digest,
         detail=json.dumps({"name": name, "mode": mode, "source": source, "ref": ref,
                            "commit": commit_sha, "tree_hash": tree_hash,
-                           "cap_add": cap_add, "devices": devices})))
+                           "cap_add": cap_add, "devices": devices,
+                           "operator_debug": operator_debug})))
 
     log.info("Deployed %s from %s@%s (%s)", name, source, ref or "HEAD", commit_sha[:12])
     return project
@@ -282,6 +288,9 @@ async def _deploy_image(store: ProjectStore, audit_manager,
     devices = manifest.get("devices", []) or []
     if (cap_add or devices) and mode != "attested":
         raise ValueError("cap_add/devices require mode=attested")
+    operator_debug = bool(manifest.get("operator_debug", False))
+    if operator_debug and mode != "attested":
+        raise ValueError("operator_debug requires mode=attested")
     env_vars = manifest.get("env", {})
 
     listen_manifest = manifest.get("listen") or {}
@@ -308,6 +317,7 @@ async def _deploy_image(store: ProjectStore, audit_manager,
         image=image, image_port=image_port, volumes=volumes,
         env_passthrough=env_passthrough, listen=listen_config,
         oci_runtime=oci_runtime, cap_add=cap_add, devices=devices,
+        operator_debug=operator_debug,
     )
     store.save(project)
 
@@ -319,7 +329,10 @@ async def _deploy_image(store: ProjectStore, audit_manager,
     await audit.record(AuditEntry(
         timestamp=time.time(), action="deploy", image=image, image_digest=digest,
         detail=json.dumps({"name": name, "image": image, "image_port": image_port,
-                           "image_digest": digest, "cap_add": cap_add, "devices": devices})))
+                           "image_digest": digest, "commit": manifest.get("commit_sha", ""),
+                           "tree_hash": manifest.get("tree_hash", ""),
+                           "cap_add": cap_add, "devices": devices,
+                           "operator_debug": operator_debug})))
 
     log.info("Deployed image project %s from %s (digest %s)", name, image, digest[:19])
     return project

--- a/proxy/evidence.py
+++ b/proxy/evidence.py
@@ -49,12 +49,20 @@ class SourceInfo:
 
 
 @dataclass
+class OperatorDebugInfo:
+    """RFC 0029 declared operator-debug door facts (a fact, not a verdict)."""
+    enabled: bool = False
+    last_session_at: str = ""  # null until Half B opens audited sessions
+
+
+@dataclass
 class AppInfo:
     """App-specific information."""
     project: str = ""
     source: SourceInfo = field(default_factory=SourceInfo)
     image_digest: str = ""
     binding_quote: dict = field(default_factory=dict)  # Daemon's promotion quote binding tree_hash
+    operator_debug: OperatorDebugInfo = field(default_factory=OperatorDebugInfo)
 
 
 @dataclass
@@ -161,6 +169,7 @@ async def fetch_bundle(endpoint: str, name: str, session: aiohttp.ClientSession)
                     source=SourceInfo(**data.get("app", {}).get("source", {})),
                     image_digest=data.get("app", {}).get("image_digest", ""),
                     binding_quote=data.get("app", {}).get("binding_quote", {}),
+                    operator_debug=OperatorDebugInfo(**(data.get("app", {}).get("operator_debug") or {})),
                 ),
             )
     except Exception as e:

--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -879,6 +879,9 @@ class Ingress:
                 ),
                 image_digest=project.image_digest or "",
                 binding_quote=binding_quote,
+                operator_debug=evidence.OperatorDebugInfo(
+                    enabled=bool(project.operator_debug),
+                ),
             )
 
             # Get audit log (retained for backward compatibility, in main bundle for now)

--- a/proxy/projects.py
+++ b/proxy/projects.py
@@ -42,6 +42,10 @@ class Project:
     # for an in-container OpenVPN sidecar (CAP_NET_ADMIN + /dev/net/tun).
     cap_add: List[str] = field(default_factory=list)
     devices: List[str] = field(default_factory=list)
+    # RFC 0029: a declared, measured operator-debug door (full trust, audited). Honored
+    # ONLY for mode=="attested" (see deploy gate), so the door is always on the verifiable
+    # surface — its existence is part of the measurement, never a hidden side channel.
+    operator_debug: bool = False
 
     def __post_init__(self):
         if self.env is None:

--- a/proxy/templates/console.html
+++ b/proxy/templates/console.html
@@ -124,6 +124,15 @@
             background: #e6fffa;
             color: #285e61;
         }
+        .badge.operator-debug {
+            background: #fefcbf;
+            color: #744210;
+        }
+        .lockdown-hint code {
+            background: #fffaf0;
+            padding: 0 0.2rem;
+            border-radius: 3px;
+        }
         .links {
             display: flex;
             gap: 0.5rem;
@@ -357,13 +366,19 @@
             const isolationBadge = project.isolation && project.isolation !== 'shared'
                 ? `<span class="badge isolation">${project.isolation}</span>`
                 : '';
+            const operatorDebugBadge = project.operator_debug
+                ? `<span class="badge operator-debug" title="Declared operator-debug door (RFC 0029)">operator-debug</span>`
+                : '';
 
             const ladder = project.ladder;
+            const lockDownHint = project.operator_debug
+                ? ` · <span class="lockdown-hint">remove <code>operator_debug</code> &amp; re-promote for fully-locked attested</span>`
+                : '';
             const ladderRow = ladder ? `
                 <tr class="ladder-row">
                     <td></td>
                     <td colspan="7">
-                        <span class="ladder-rung">${escapeHtml(ladder.label)}</span> · ${escapeHtml(ladder.next)}
+                        <span class="ladder-rung">${escapeHtml(ladder.label)}</span> · ${escapeHtml(ladder.next)}${lockDownHint}
                     </td>
                 </tr>
             ` : '';
@@ -378,6 +393,7 @@
                     <td>
                         <span class="badge runtime">${project.runtime}</span>
                         ${isolationBadge}
+                        ${operatorDebugBadge}
                     </td>
                     <td class="mono">${project.source || '-'}</td>
                     <td class="mono">${shortCommit}</td>

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -166,6 +166,44 @@ def test_caps_require_attested():
     print("  attested + caps accepted and surfaced on project ✓")
 
 
+def test_operator_debug():
+    """RFC 0029 Half A: operator_debug is a measured bool gated to attested mode."""
+    print("\n--- Test: operator_debug requires mode=attested (RFC 0029) ---")
+    repo = create_test_repo("test-opdebug", {
+        "index.html": b"<html><body>operator-debug</body></html>",
+    })
+    # dev mode (default) + operator_debug => rejected (door must be on the attested surface)
+    resp = api_post("/projects", json={"name": "test-opdebug", "source": repo,
+                                       "runtime": "static", "operator_debug": True})
+    assert resp.status_code >= 400, f"dev-mode operator_debug should be rejected, got {resp.status_code}"
+    assert "operator_debug requires mode=attested" in resp.text, resp.text
+    print(f"  dev-mode + operator_debug rejected ({resp.status_code}) ✓")
+    # attested mode + operator_debug => accepted, surfaced on project + verification bundle
+    resp = api_post("/projects", json={"name": "test-opdebug", "source": repo,
+                                       "runtime": "static", "mode": "attested",
+                                       "operator_debug": True})
+    assert resp.status_code == 201, f"attested operator_debug deploy failed: {resp.status_code} {resp.text}"
+    project = resp.json()
+    assert project["operator_debug"] is True, project
+    print("  attested + operator_debug accepted and surfaced on project ✓")
+    # The door is a live RFC 0020 fact in the verification bundle's app block
+    resp = api_get("/verification/test-opdebug")
+    assert resp.status_code == 200, f"verification failed: {resp.text}"
+    od = resp.json()["app"]["operator_debug"]
+    assert od["enabled"] is True, od
+    assert od["last_session_at"] == "", od  # null until Half B
+    print(f"  verification bundle surfaces operator_debug={od} ✓")
+    # A plain attested project (no door) reports enabled=False, not a missing key
+    repo2 = create_test_repo("test-opdebug-off", {"index.html": b"off"})
+    resp = api_post("/projects", json={"name": "test-opdebug-off", "source": repo2,
+                                       "runtime": "static", "mode": "attested"})
+    assert resp.status_code == 201, resp.text
+    resp = api_get("/verification/test-opdebug-off")
+    assert resp.status_code == 200, resp.text
+    assert resp.json()["app"]["operator_debug"]["enabled"] is False
+    print("  attested without operator_debug reports enabled=False ✓")
+
+
 def test_ingress_static():
     print("\n--- Test: static serving ---")
     resp = requests.get(f"{INGRESS}/test-static/")
@@ -942,7 +980,7 @@ def await_if_needed(func, *args, **kwargs):
 
 def test_teardown():
     print("\n--- Test: teardown ---")
-    for name in ["test-static", "test-deno", "test-auto", "test-tarball", "test-image", "test-iso-a", "test-iso-b", "test-passthru", "test-iso-passthru", "test-redeploy-img", "net-a", "net-b", "data-iso", "rfc-test"]:
+    for name in ["test-static", "test-caps", "test-deno", "test-auto", "test-tarball", "test-image", "test-iso-a", "test-iso-b", "test-passthru", "test-iso-passthru", "test-redeploy-img", "net-a", "net-b", "data-iso", "rfc-test", "test-opdebug", "test-opdebug-off"]:
         resp = api_delete(f"/projects/{name}")
         if resp.status_code == 200:
             print(f"  Torn down: {name}")
@@ -959,6 +997,7 @@ def main():
         test_version()
         test_deploy_static()
         test_caps_require_attested()
+        test_operator_debug()
         test_ingress_static()
         test_scoped_tokens()
         test_git_blocked()

--- a/verify/facts.py
+++ b/verify/facts.py
@@ -93,6 +93,13 @@ class SourceFacts:
 
 
 @dataclass
+class OperatorDebugFacts:
+    """RFC 0029 declared operator-debug door facts (a fact, not a verdict)."""
+    enabled: bool = False
+    last_session_at: str = ""  # null until Half B opens audited sessions
+
+
+@dataclass
 class Facts:
     """
     Complete attestation facts for a TEE-hosted app.
@@ -116,6 +123,7 @@ class Facts:
     channel: ChannelFacts = field(default_factory=ChannelFacts)
     app_id: str = ""
     attestation_kind: Literal["daemon-vouched", "app-cvm", "unknown"] = "unknown"
+    operator_debug: OperatorDebugFacts = field(default_factory=OperatorDebugFacts)
     quote: QuoteFacts = field(default_factory=QuoteFacts)
     binding: BindingFacts = field(default_factory=BindingFacts)
     onchain: OnchainFacts = field(default_factory=OnchainFacts)
@@ -134,6 +142,10 @@ class Facts:
             },
             "app_id": self.app_id,
             "attestation_kind": self.attestation_kind,
+            "operator_debug": {
+                "enabled": self.operator_debug.enabled,
+                "last_session_at": self.operator_debug.last_session_at,
+            },
             "quote": {
                 "quote_valid": self.quote.quote_valid,
                 "quote_format": self.quote.quote_format,
@@ -521,6 +533,12 @@ async def verify(
         # RFC 0025: app-cvm would have a different quote structure
         facts.attestation_kind = "daemon-vouched"
 
+        # RFC 0029: surface the declared operator-debug door as a fact (no verdict).
+        app_block = bundle_data.get("app", {}) or {}
+        od = app_block.get("operator_debug") or {}
+        facts.operator_debug.enabled = bool(od.get("enabled", False))
+        facts.operator_debug.last_session_at = od.get("last_session_at", "") or ""
+
         # Verify quote
         facts.quote = _verify_quote_signature(quote_data)
         if facts.quote.verification_error:
@@ -595,6 +613,12 @@ async def verify_from_bundle(bundle_data: dict, chain_config: dict | None = None
             facts.binding.app_pubkey = quote_data.get("pubkey", "")
 
         facts.attestation_kind = "daemon-vouched"
+
+        # RFC 0029: surface the declared operator-debug door as a fact (no verdict).
+        app_block = bundle_data.get("app", {}) or {}
+        od = app_block.get("operator_debug") or {}
+        facts.operator_debug.enabled = bool(od.get("enabled", False))
+        facts.operator_debug.last_session_at = od.get("last_session_at", "") or ""
 
         # Verify quote
         facts.quote = _verify_quote_signature(quote_data)


### PR DESCRIPTION
## What it does
Implements **Half A only** of RFC 0029 (#66): a single measured boolean `operator_debug` on the `Project` model, gated to `mode=attested`, surfaced as an RFC 0020 fact in the verification bundle and on the console. **Half B (opening actual debug sessions) is intentionally deferred** — it rides RFC 0026's debug broker (#58, unimplemented); this PR does declaration + disclosure only.

## What you get by merging
An operator who needs to poke a running attested app can now **say so up front** instead of keeping a hidden side channel. The declaration is part of the measured surface (source: committed in `project.json` → `tree_hash` commits to it; image: bound by audit detail + pinned digest), so a declared door never silently voids the attestation — `verify()` reports `operator_debug.enabled` as a **fact** (no verdict), and a consumer can allowlist or reject it. Mirrors the existing `cap_add`/`devices` ⟹attested gate (RFC 0025) exactly.

- **Gate:** `operator_debug` ⟹ `mode=attested`, in both deploy paths (`deploy.py` source + image). Dev-mode + `operator_debug:true` → `400 "operator_debug requires mode=attested"`.
- **Evidence:** `AppInfo` gains `operator_debug: { enabled, last_session_at }` (last_session_at stays `""` until Half B). `/_api/verification/<name>` now shows `app.operator_debug.enabled`. `verify/facts.py` `Facts` gets the sibling fact so consumers have a place to read it.
- **Console:** an `operator-debug` badge + a lock-down hint ("remove `operator_debug` & re-promote for fully-locked attested") on projects where it's true.

## Risk / what to watch
- **No session-opening here** — declaring `operator_debug:true` changes what a *verifier sees*, not what an *operator can do* today. Until Half B (the RFC 0026 broker), the door is declared but not reachable through any daemon path. That is the correct honest state for Half A; do **not** assume a declared door is currently openable.
- **Load-bearing invariant (RFC 0029 §5) still rests on Half B:** the disclosure is only honest if the audited broker is the *only* way to reach the container. This PR does not change that surface; it only makes the intent legible.
- Schema additive only — old consumers ignore the new `operator_debug` key; no breaking change to existing bundles.

## Drive-by fixes (needed to turn the staging suite green — it was red before this PR)
While running the gate I found `test_daemon.py` was already **red on `origin/staging`** (verified by running the suite on a clean staging worktree) on two unrelated, pre-existing failures. Both block the green gate for this and every future PR, so I fixed them minimally here:
1. **`test_audit_log`** asserted every deploy audit entry has `commit`+`tree_hash`, but the image-deploy audit detail never recorded them → added `commit`/`tree_hash` (empty when no source, which is honest — image projects *can* carry them via manifest) to the image deploy detail.
2. **`test_teardown`** left `test-caps` (created by `test_caps_require_attested`, cleaned by neither self-cleanup nor the teardown list) on disk → added it to the teardown list.

Neither is related to `operator_debug`; both are root-cause, one-line fixes.

## Verification
- `test_daemon.py` — **ALL TESTS PASSED** (full e2e suite, real docker). New `test_operator_debug` covers: dev-mode rejection, attested acceptance, `app.operator_debug.enabled:true` in the bundle, and `enabled:false` for a plain attested project. Log: `~/paseo-batch/out/66/test.log`.
- **Built image runs from this PR's commit** — `docker build` + `docker run` of the daemon image from `f20c5cc4`, then `GET /_api/version` → `{"version": "dev", "commit": "f20c5cc4"}` (pinned below). This proves the daemon image builds and serves from this PR's source, not just that unit tests pass.
- **webhost-staging deploy NOT performed** — `ship-fix.sh staging` requires `docker-compose.webhost-staging.yaml` + `.env.webhost-staging` (under `~/projects/hermes-agent/deploy-notes/`), which are **not present in this environment** (only the prod compose exists, which I do not touch). The operator should run `ship-fix.sh staging` to pin the deployed commit on webhost-staging.

`/_api/version` from the locally-built-and-run image (commit `f20c5cc4` = this PR):
```json
{"version": "dev", "commit": "f20c5cc4"}
```

<details><summary>Diff stat</summary>

```
 proxy/deploy.py              | 19 ++++++++++++++++---
 proxy/evidence.py            |  9 +++++++++
 proxy/ingress.py             |  3 +++
 proxy/projects.py            |  4 ++++
 proxy/templates/console.html | 18 +++++++++++++++++-
 test_daemon.py               | 41 ++++++++++++++++++++++++++++++++++++++++-
 verify/facts.py              | 24 ++++++++++++++++++++++++
 7 files changed, 113 insertions(+), 5 deletions(-)
```
</details>