### PR TITLE
test(tier0): guard source binding across dev→promote (#70)

### DIFF
--- a/test_daemon.py
+++ b/test_daemon.py
@@ -970,6 +970,55 @@ def test_rfc0020_source_pull():
         print(f"  Skipping git tree check (tree_hash_kind={facts.source.tree_hash_kind})")
 
 
+def test_tier0_source_binding_survives_promote():
+    """Tier-0 gate journey: source-backed dev deploy -> promote -> the evidence
+    bundle still binds the deploy-time tree_hash.
+
+    Mirrors oauth3-apps/harness/tier0-journeys.sh (journey 2/3): a source-backed
+    app is deployed with no mode (dev, the default) then promoted to attested,
+    and the verification bundle must surface app.source.tree_hash equal to the
+    deploy-time value. Existing bundle tests deploy directly in attested mode,
+    so they never exercise the promote() round-trip that this journey depends on.
+    """
+    print("\n--- Test: Tier-0 source binding survives dev->promote ---")
+    repo = create_test_repo("tier0-src", {"index.html": b"<html>tier0 source binding</html>"})
+    # Deploy with NO mode (dev, the default) — exactly like tier0 deploy_source.
+    resp = api_post("/projects", json={
+        "name": "tier0-src", "source": repo, "runtime": "static", "entry": "index.html"})
+    assert resp.status_code == 201, f"deploy failed: {resp.status_code} {resp.text}"
+    deploy = resp.json()
+    assert deploy["mode"] == "dev", deploy
+    deploy_tree_hash = deploy["tree_hash"]
+    assert deploy_tree_hash, "source-backed deploy must produce a tree_hash"
+    print(f"  deployed dev: tree_hash={deploy_tree_hash[:12]}")
+
+    # Promote to attested — the journey step whose bundle effect was untested.
+    resp = api_post(f"/projects/tier0-src/promote")
+    assert resp.status_code == 200, f"promote failed: {resp.status_code} {resp.text}"
+    assert resp.json()["mode"] == "attested", resp.json()
+    print("  promoted to attested ✓")
+
+    # The evidence bundle must still bind the deploy-time tree_hash.
+    resp = api_get("/verification/tier0-src")
+    assert resp.status_code == 200, f"verification failed: {resp.text}"
+    bundle = resp.json()
+    src = (bundle.get("app") or {}).get("source") or {}
+    th = src.get("tree_hash", "")
+    assert th, ("SOURCE BINDING MISSING: app.source.tree_hash absent after promote "
+                f"(bundle app={bundle.get('app')!r})")
+    assert th == deploy_tree_hash, (
+        f"source binding drifted: bundle {th[:12]} != deploy-time {deploy_tree_hash[:12]}")
+    print(f"  bundle app.source.tree_hash == deploy-time binding {th[:12]} ✓")
+
+    # The promote must be persisted to the audit log (pha gate showed only 1
+    # entry when this regressed — promote didn't complete). Assert it here so a
+    # half-finished promote can't pass the gate silently.
+    actions = [e.get("action") for e in (bundle.get("audit") or [])]
+    assert "deploy" in actions and "promote" in actions, (
+        f"audit missing promote entry: actions={actions}")
+    print(f"  audit recorded deploy+promote: {actions} ✓")
+
+
 def await_if_needed(func, *args, **kwargs):
     """Helper to run async functions in sync context if needed."""
     import asyncio
@@ -980,7 +1029,7 @@ def await_if_needed(func, *args, **kwargs):
 
 def test_teardown():
     print("\n--- Test: teardown ---")
-    for name in ["test-static", "test-caps", "test-deno", "test-auto", "test-tarball", "test-image", "test-iso-a", "test-iso-b", "test-passthru", "test-iso-passthru", "test-redeploy-img", "net-a", "net-b", "data-iso", "rfc-test", "test-opdebug", "test-opdebug-off"]:
+    for name in ["test-static", "test-caps", "test-deno", "test-auto", "test-tarball", "test-image", "test-iso-a", "test-iso-b", "test-passthru", "test-iso-passthru", "test-redeploy-img", "net-a", "net-b", "data-iso", "rfc-test", "test-opdebug", "test-opdebug-off", "tier0-src"]:
         resp = api_delete(f"/projects/{name}")
         if resp.status_code == 200:
             print(f"  Torn down: {name}")
@@ -1028,6 +1077,7 @@ def main():
         test_rfc0020_non_anchored()
         test_rfc0020_two_policies()
         test_rfc0020_source_pull()
+        test_tier0_source_binding_survives_promote()
         test_teardown()
         print("\n=== ALL TESTS PASSED ===")
     except Exception:


### PR DESCRIPTION
## What it does
Adds `test_tier0_source_binding_survives_promote` to `test_daemon.py` — a regression guard that mirrors the Tier-0 gate journey (`oauth3-apps/harness/tier0-journeys.sh` journey 2/3): deploy a source-backed app with **no mode** (dev) → **promote** to attested → assert the verification bundle still binds the deploy-time `app.source.tree_hash` and that the promote was recorded to the audit log.

## What you get by merging
- **Closes a real coverage gap.** `test_rfc0020_bundle` deploys *directly* in attested mode; no test exercised the `promote()` round-trip the Tier-0 gate actually depends on. The gate's exact path was unguarded locally.
- **Catches the regression class for free next time.** If a future change ever drops `tree_hash` across promote (e.g. a load/save round-trip bug), this fails the local gate before pha does.
- **An honest root-cause finding for the pha RED** (see below) — this is the part the operator needs to read.

## Root-cause investigation (important — read before merging)
I could **not** reproduce the pha failure from the staging code, and the evidence says the staging code is correct:

1. **PR #69 did not touch the source-binding path.** Its only change to `proxy/evidence.py` bundle-building was adding `OperatorDebugInfo`; `to_dict()` / the `app.source` serialization were unchanged. Verified by `git diff 48320978^..48320978 -- proxy/evidence.py`.
2. **The Tier-0 harness does raw JSON** (`(d.get("app") or {}).get("source") or {}`) — it does *not* import `verify/facts.py`, so the verifier lib is not in the gate path.
3. **Local repro of the exact Tier-0 flow is GREEN.** I ran dev-deploy → promote → verify against a live daemon: the bundle's `app.source.tree_hash` matched the deploy-time binding, and audit had **2** entries (`deploy`, `promote`).

**The pha log shows an anomaly that is impossible under the current staging code:** the deploy response *had* `tree_hash=e9da8d1f…`, yet the bundle lacked it, and — critically — `audit present (1 entries)` instead of 2. Both the deploy response and `project.json` are `asdict(project)`, so `tree_hash` cannot vanish from one but not the other; and a completed promote always appends an audit entry. One audit entry + missing tree_hash ⇒ **promote did not complete on pha**. That points at the pha environment (daemon health / storage / deploy pipeline not actually running this staging commit), **not a staging code defect.**

**Conclusion:** merging this guards the code; it will *not* by itself turn the pha gate GREEN, because the pha failure is not a staging-code bug. The pha-side promote-not-completing issue needs a separate look (is the pha daemon actually running commit `05cfad99`/staging HEAD? is its project store healthy?).

## Risk / what to watch
- **Test-only — zero daemon behavior change, zero deploy risk.**
- The honest risk is expectation-setting: this PR does **not** fix the pha gate. If you merge expecting pha to go green, it won't until the pha-side issue is resolved.

## Verification
`test_daemon.py` — **ALL TESTS PASSED** (exit 0), including the new test:
```
--- Test: Tier-0 source binding survives dev->promote ---
  deployed dev: tree_hash=08c8b8a39026
  promoted to attested ✓
  bundle app.source.tree_hash == deploy-time binding 08c8b8a39026 ✓
  audit recorded deploy+promote: ['deploy', 'promote'] ✓
```
Full log saved at `~/paseo-batch/out/70/test.log` (on zed). Backend-only — no visual evidence. No daemon behavior changed, so no deploy is required by the rubric.

<details><summary>diff stat</summary>

```
 test_daemon.py | 52 +++++++++++++++++++++++++++++++++++++++++++++++++++-
 1 file changed, 51 insertions(+), 1 deletion(-)
```
commit `05cfad99`
</details>