### PR TITLE
Scope broker GetKey to requesting project — fixes #7 (#80)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,21 +13,21 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
       - /var/run/dstack.sock:/var/run/dstack.sock:ro
       - daemon_data:/var/lib/tee-daemon
-      # Broker-ONLY named volume. The daemon serves the already-filtered dstack
-      # broker at <BROKER_SOCKET_DIR>/dstack.sock here and nothing else (NOT
-      # docker.sock, which stays in PROXY_DIR off this volume). Attested app
-      # containers mount the same volume at /run/broker (see BROKER_VOLUME_NAME),
-      # so the broker appears at /run/broker/dstack.sock inside them.
-      - broker_sock:/var/run/broker
+      # Per-project broker sockets live under here (one subdir per project, each
+      # holding that project's dstack.sock + creds.sock). It MUST be a host bind
+      # (not a named volume) so the daemon can bind a project's OWN subdir into
+      # that project's container at /run/broker — a tenant must only ever see
+      # its own broker dir (cross-tenant GetKey derivation, issue #7).
+      # BROKER_HOST_PATH names the host side.
+      - ${BROKER_HOST_PATH:-/var/run/tee-broker}:/var/run/broker
     environment:
       - TEE_DAEMON_TOKEN=${TEE_DAEMON_TOKEN}
       - DAEMON_VOLUME_NAME=${DAEMON_VOLUME_NAME:-}
       - DAEMON_VOLUME_MOUNT=${DAEMON_VOLUME_MOUNT:-/var/lib/tee-daemon}
-      # Set to the *resolved* docker volume name of broker_sock (compose prefixes
-      # it with the project name, e.g. "dstack_broker_sock"), mirroring how
-      # DAEMON_VOLUME_NAME is wired. When set, attested app containers get ONLY
-      # the broker mounted at /run/broker/dstack.sock. Leave empty to disable.
-      - BROKER_VOLUME_NAME=${BROKER_VOLUME_NAME:-}
+      # Host path backing the daemon's BROKER_SOCKET_DIR, so per-project subdirs
+      # can be bind-mounted into each app's container. Must match the host side
+      # of the /var/run/broker bind above.
+      - BROKER_HOST_PATH=${BROKER_HOST_PATH:-/var/run/tee-broker}
       - BROKER_SOCKET_DIR=${BROKER_SOCKET_DIR:-/var/run/broker}
 
 # Durability (RFC-0017): daemon_data holds ALL private state — project metadata,
@@ -41,4 +41,3 @@ services:
 volumes:
   daemon_data:
     # external: true   # uncomment + pre-create for operator-managed durability
-  broker_sock:

--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -350,6 +350,8 @@ async def deploy(store: ProjectStore, docker: DockerClient, audit_manager,
     )
     store.save(project)
 
+    await rtm.ensure_project_broker(name)
+
     if isolation == "container" and runtime in ("deno", "bun"):
         digest = await rtm.start_isolated(project)
     else:
@@ -425,6 +427,8 @@ async def _deploy_image(store: ProjectStore, audit_manager,
     )
     store.save(project)
 
+    await rtm.ensure_project_broker(name)
+
     digest = await rtm.start_image(project)
     project.image_digest = digest
     store.save(project)
@@ -459,6 +463,8 @@ async def teardown(store: ProjectStore, docker: DockerClient, audit_manager,
         await rtm.stop_isolated(name)
     elif project.runtime not in ("static", "dockerfile"):
         await rtm.refresh(project.runtime)
+
+    await rtm.remove_project_broker(name)
 
     log.info("Torn down %s", name)
 

--- a/proxy/dstack_proxy.py
+++ b/proxy/dstack_proxy.py
@@ -1,7 +1,18 @@
-"""dstack socket proxy — filters dstack JSON-RPC API requests."""
+"""dstack socket proxy — filters dstack JSON-RPC API requests.
+
+Each proxy instance is scoped to ONE project (``project_id``). ``GetKey`` never
+trusts a caller-supplied ``path``: it reads a ``name`` (a single safe path
+component) and constructs the key path server-side as
+``/tee-daemon/projects/<project_id>/<name>``. The daemon serves one such proxy
+per project on its own socket (see :class:`DstackProxyManager`), so a tenant can
+only ever derive its OWN project's keys — closing the cross-tenant derivation
+flaw (#7). A project's container is mounted only its own broker dir, so it
+cannot even reach another project's socket.
+"""
 
 import json
 import logging
+import os
 
 import aiohttp
 from aiohttp import web
@@ -9,12 +20,20 @@ from aiohttp import web
 log = logging.getLogger(__name__)
 
 ALLOWED_METHODS = {"GetTlsKey", "GetQuote", "Info", "EmitEvent", "GetKey"}
-KEY_PATH_PREFIX = "/tee-daemon/"
+PROJECT_KEY_PREFIX = "/tee-daemon/projects/"
+
+
+def _valid_key_name(name: str) -> bool:
+    """A GetKey ``name`` must be a single safe path component (no traversal)."""
+    if not name:
+        return False
+    return not ("/" in name or "\\" in name or ".." in name or name.startswith("."))
 
 
 class DstackProxy:
-    def __init__(self, real_socket: str):
+    def __init__(self, real_socket: str, project_id: str):
         self.real_socket = real_socket
+        self.project_id = project_id
 
     async def handle(self, request: web.Request) -> web.Response:
         body_bytes = await request.read()
@@ -32,19 +51,27 @@ class DstackProxy:
             return web.json_response({"message": f"Method {method} not permitted"}, status=403)
 
         if method == "GetKey":
-            path = body.get("path", "")
-            if not path.startswith(KEY_PATH_PREFIX):
-                log.warning("Denied GetKey with path: %s", path)
+            # The key path is derived from THIS proxy's bound project identity,
+            # never from a caller-supplied field — a tenant cannot name another
+            # project's key path (issue #7). Any legacy `path` is ignored.
+            name = body.get("name", "")
+            if not _valid_key_name(name):
+                log.warning("Denied GetKey for project %s with bad name: %r",
+                            self.project_id, name)
                 return web.json_response(
-                    {"message": f"GetKey path must start with {KEY_PATH_PREFIX}"},
-                    status=403,
+                    {"message": "GetKey requires a `name` (no '/', '\\', '..', or leading '.')"},
+                    status=400,
                 )
+            body["path"] = f"{PROJECT_KEY_PREFIX}{self.project_id}/{name}"
+            body_bytes = json.dumps(body).encode()
 
         return await self._forward(request.method, request.path, body_bytes, request.headers)
 
     async def _forward(self, method: str, path: str, body: bytes, headers) -> web.Response:
+        # Drop hop-by-hop headers. Content-Length is dropped because GetKey rewrites
+        # the body (a stale length would truncate the forwarded request).
         fwd_headers = {k: v for k, v in headers.items()
-                       if k.lower() not in ("host", "transfer-encoding")}
+                       if k.lower() not in ("host", "transfer-encoding", "content-length")}
         conn = aiohttp.UnixConnector(path=self.real_socket)
         async with aiohttp.ClientSession(connector=conn) as session:
             async with session.request(method, f"http://localhost{path}",
@@ -56,3 +83,77 @@ class DstackProxy:
                     status=resp.status,
                     content_type=resp.content_type,
                 )
+
+
+class DstackProxyManager:
+    """Serves one project-scoped :class:`DstackProxy` per project, plus the
+    shared ``BrokerProxy`` (``creds.sock``), each inside its own subdirectory of
+    ``broker_socket_dir``. A project's container is mounted ONLY its own subdir,
+    so it sees ``/run/broker/dstack.sock`` and ``/run/broker/creds.sock`` and
+    nothing else — it cannot reach another project's sockets."""
+
+    def __init__(self, real_socket: str, broker_socket_dir: str,
+                 broker_proxy_runner=None):
+        self.real_socket = real_socket
+        self.broker_socket_dir = broker_socket_dir
+        self.broker_proxy_runner = broker_proxy_runner  # shared creds.sock AppRunner, or None
+        # project -> (dstack AppRunner, [BaseSite, ...])
+        self._projects: dict[str, tuple[web.AppRunner, list]] = {}
+
+    async def ensure(self, project_id: str):
+        if project_id in self._projects:
+            return
+        pdir = os.path.join(self.broker_socket_dir, project_id)
+        os.makedirs(pdir, exist_ok=True)
+
+        proxy = DstackProxy(self.real_socket, project_id)
+        app = web.Application()
+        app.router.add_route("*", "/{path:.*}", proxy.handle)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        sites: list = []
+
+        dstack_sock = os.path.join(pdir, "dstack.sock")
+        if os.path.exists(dstack_sock):
+            os.unlink(dstack_sock)
+        site = web.UnixSite(runner, dstack_sock)
+        await site.start()
+        os.chmod(dstack_sock, 0o666)
+        sites.append(site)
+
+        # creds.sock is token-authenticated per call (BrokerProxy), so the same
+        # runner is safe to serve on every project's socket. Riding the project
+        # subdir keeps a single /run/broker mount for both sockets.
+        if self.broker_proxy_runner is not None:
+            creds_sock = os.path.join(pdir, "creds.sock")
+            if os.path.exists(creds_sock):
+                os.unlink(creds_sock)
+            csite = web.UnixSite(self.broker_proxy_runner, creds_sock)
+            await csite.start()
+            os.chmod(creds_sock, 0o666)
+            sites.append(csite)
+
+        self._projects[project_id] = (runner, sites)
+        log.info("Project broker for %s at %s/dstack.sock", project_id, pdir)
+
+    async def remove(self, project_id: str):
+        entry = self._projects.pop(project_id, None)
+        if not entry:
+            return
+        runner, sites = entry
+        for s in sites:
+            try:
+                await s.stop()
+            except Exception as e:
+                log.debug("stop site for %s: %s", project_id, e)
+        await runner.cleanup()
+        pdir = os.path.join(self.broker_socket_dir, project_id)
+        for fn in ("dstack.sock", "creds.sock"):
+            try:
+                os.unlink(os.path.join(pdir, fn))
+            except FileNotFoundError:
+                pass
+
+    async def stop_all(self):
+        for pid in list(self._projects):
+            await self.remove(pid)

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -10,7 +10,7 @@ from aiohttp import web
 from .tracker import ContainerTracker
 from .audit import AuditLogManager
 from .docker_proxy import DockerProxy
-from .dstack_proxy import DstackProxy
+from .dstack_proxy import DstackProxyManager
 from .docker_client import DockerClient
 from .projects import ProjectStore
 from .runtimes import RuntimeManager
@@ -87,26 +87,37 @@ async def start():
     os.chmod(docker_sock_path, 0o666)
     log.info("Docker proxy listening on %s", docker_sock_path)
 
-    # dstack socket proxy (existing)
+    # dstack + credential broker proxies. One project-scoped DstackProxy per
+    # project (GetKey derives the key path from the bound project identity, never
+    # a caller-supplied path — issue #7), served in its own subdir of
+    # BROKER_SOCKET_DIR alongside creds.sock. Set up BEFORE recover_all so the
+    # per-project sockets exist when recovered containers mount them.
+    broker_mgr = None
     if dstack_sock:
-        dstack_proxy = DstackProxy(dstack_sock)
-        dstack_app = web.Application()
-        dstack_app.router.add_route("*", "/{path:.*}", dstack_proxy.handle)
-        # Serve in BROKER_SOCKET_DIR (NOT PROXY_DIR) so apps can be given the
-        # broker without also getting docker.sock.
-        dstack_sock_path = os.path.join(BROKER_SOCKET_DIR, "dstack.sock")
-        if os.path.exists(dstack_sock_path):
-            os.unlink(dstack_sock_path)
-        dstack_runner = web.AppRunner(dstack_app)
-        await dstack_runner.setup()
-        await web.UnixSite(dstack_runner, dstack_sock_path).start()
-        os.chmod(dstack_sock_path, 0o666)
-        log.info("dstack proxy (filtered broker) listening on %s", dstack_sock_path)
-        if os.environ.get("BROKER_VOLUME_NAME"):
-            log.info("Broker shared to attested apps via BROKER_VOLUME_NAME=%s "
-                     "(appears at /run/broker/dstack.sock)", os.environ["BROKER_VOLUME_NAME"])
+        await broker_store.recover()
+        log.info("Recovered %d active grants", len(broker_store.list()))
+        rtm.set_broker_store(broker_store)
+
+        # Shared BrokerProxy (creds.sock) — token-authed per call, so the same
+        # runner is safe to serve on every project's socket.
+        broker_proxy = BrokerProxy(broker_store, rtm)
+        broker_app = web.Application()
+        broker_app.router.add_route("*", "/{path:.*}", broker_proxy.handle)
+        broker_runner = web.AppRunner(broker_app)
+        await broker_runner.setup()
+
+        broker_mgr = DstackProxyManager(dstack_sock, BROKER_SOCKET_DIR, broker_runner)
+        rtm.set_broker_proxy_manager(broker_mgr)
+        for p in store.list():
+            await broker_mgr.ensure(p.name)
+        log.info("Serving %d project-scoped broker sockets under %s",
+                 len(store.list()), BROKER_SOCKET_DIR)
+        if os.environ.get("BROKER_HOST_PATH"):
+            log.info("Broker mounted per-project via BROKER_HOST_PATH=%s "
+                     "(each app sees only its own /run/broker)",
+                     os.environ["BROKER_HOST_PATH"])
     else:
-        log.warning("dstack socket not found — dstack proxy disabled")
+        log.warning("dstack socket not found — dstack proxy + broker disabled")
 
     # Recovery: restore shared runtimes for existing projects
     await rtm.recover_all()
@@ -118,29 +129,6 @@ async def start():
     # Recovery: restore scoped API tokens from disk
     token_store.recover()
     log.info("Recovered %d scoped API tokens", len(token_store.list()))
-
-    # Recovery: restore broker grants from disk
-    if dstack_sock:
-        await broker_store.recover()
-        log.info("Recovered %d active grants", len(broker_store.list()))
-
-        # Pass broker_store to RuntimeManager for token auth
-        rtm.set_broker_store(broker_store)
-
-        # Serve creds.sock in BROKER_SOCKET_DIR (rides the broker volume)
-        broker_proxy = BrokerProxy(broker_store, rtm)
-        broker_app = web.Application()
-        broker_app.router.add_route("*", "/{path:.*}", broker_proxy.handle)
-        creds_sock_path = os.path.join(BROKER_SOCKET_DIR, "creds.sock")
-        if os.path.exists(creds_sock_path):
-            os.unlink(creds_sock_path)
-        broker_runner = web.AppRunner(broker_app)
-        await broker_runner.setup()
-        await web.UnixSite(broker_runner, creds_sock_path).start()
-        os.chmod(creds_sock_path, 0o666)
-        log.info("Broker proxy listening on %s", creds_sock_path)
-    else:
-        log.warning("dstack socket not found — broker disabled")
 
     # Ingress + API on TCP port(s)
     ing = Ingress(store, docker, audit_manager, tracker, rtm, tunnel_store, token_store, broker_store)
@@ -221,6 +209,10 @@ async def start():
         await cleanup_task
     except asyncio.CancelledError:
         pass
+
+    # Stop per-project broker sockets
+    if broker_mgr is not None:
+        await broker_mgr.stop_all()
 
     # Close TCP servers
     for server in tcp_servers:

--- a/proxy/runtimes.py
+++ b/proxy/runtimes.py
@@ -26,24 +26,19 @@ DATA_VOLUME_NAME = os.environ.get("DAEMON_DATA_VOLUME_NAME", "")
 DATA_VOLUME_MOUNT_IN_RUNTIME = "/daemon-data"
 # Named volume backing the daemon's BROKER_SOCKET_DIR, which holds ONLY the
 # already-filtered dstack broker socket (proxy/main.py serves it at
-# BROKER_SOCKET_DIR/dstack.sock). It is deliberately separate from PROXY_DIR,
-# which also holds docker.sock (the docker-control proxy) — apps must NOT get
-# that. Under Docker-in-Docker the daemon can't bind a host path into sibling
-# containers, so the broker lives on a named volume mounted by both. When set,
-# attested app containers mount it at /run/broker (broker at
-# /run/broker/dstack.sock; nothing else). Mirrors DAEMON_VOLUME_NAME.
-BROKER_VOLUME_NAME = os.environ.get("BROKER_VOLUME_NAME", "")
+# BROKER_SOCKET_DIR/<project>/dstack.sock). It is deliberately separate from
+# PROXY_DIR, which also holds docker.sock (the docker-control proxy) — apps
+# must NOT get that. Each project gets its OWN subdir (one project-scoped
+# DstackProxy per project — see dstack_proxy.DstackProxyManager), and a
+# project's container is mounted ONLY its own subdir, so it cannot reach
+# another project's broker socket (cross-tenant key derivation, issue #7).
+# Under Docker-in-Docker the daemon can't bind its own container path into a
+# sibling, so the operator points BROKER_HOST_PATH at the host path that backs
+# BROKER_SOCKET_DIR (e.g. bind-mount /var/run/tee-broker:/var/run/broker and set
+# BROKER_HOST_PATH=/var/run/tee-broker). Mirrors DAEMON_VOLUME_NAME.
+BROKER_HOST_PATH = os.environ.get("BROKER_HOST_PATH", "")
 BROKER_MOUNT_IN_APP = "/run/broker"
 IMAGE_APP_RESTART_POLICY = {"Name": "on-failure", "MaximumRetryCount": 5}
-
-
-def _attested_broker_binds(mode: str) -> list[str]:
-    """Bind ONLY the filtered dstack broker socket into attested app containers,
-    at a dedicated path (no docker.sock, no /var/run clobber).
-    Read-only is fine: connect() doesn't write the socket file."""
-    if mode != "attested" or not BROKER_VOLUME_NAME:
-        return []
-    return [f"{BROKER_VOLUME_NAME}:{BROKER_MOUNT_IN_APP}:ro"]
 
 
 def _project_uses_broker(project) -> bool:
@@ -51,6 +46,29 @@ def _project_uses_broker(project) -> bool:
     if not project.env:
         return False
     return any(str(v).startswith("broker:") for v in project.env.values())
+
+
+def _project_needs_broker(project) -> bool:
+    """A project needs its broker dir mounted if it is attested (GetKey/GetQuote
+    via the dstack proxy) or uses broker: credential handles (creds.sock)."""
+    return project.mode == "attested" or _project_uses_broker(project)
+
+
+def _project_broker_binds(project) -> list[str]:
+    """Mount ONLY this project's own broker subdir into a container-isolated
+    project's container. Read-only is fine: connect() doesn't write the socket."""
+    if not BROKER_HOST_PATH or not _project_needs_broker(project):
+        return []
+    return [f"{BROKER_HOST_PATH}/{project.name}:{BROKER_MOUNT_IN_APP}:ro"]
+
+
+def _shared_broker_binds() -> list[str]:
+    """Shared runtime (one container, many projects): co-tenants are co-trust by
+    construction (shared V8/fs/env), so per-project isolation is moot here —
+    mount the broker parent read-only for reachability."""
+    if not BROKER_HOST_PATH:
+        return []
+    return [f"{BROKER_HOST_PATH}:{BROKER_MOUNT_IN_APP}:ro"]
 # Optional OCI runtime for daemon-managed containers (e.g. "sysbox-runc").
 # Empty string keeps Docker's default (runc).
 CONTAINER_RUNTIME = os.environ.get("DAEMON_CONTAINER_RUNTIME", "")
@@ -288,6 +306,7 @@ class RuntimeManager:
         self.image_cids: dict[str, str] = {}  # project name -> cid
         self.broker_store = None  # Set by main.py after broker init
         self.broker_tokens: dict[str, str] = {}  # broker_token -> project name
+        self.broker_proxy_manager = None  # Set by main.py; per-project dstack proxies
 
     async def refresh(self, runtime: str):
         if runtime == "static" or runtime == "dockerfile":
@@ -361,14 +380,11 @@ class RuntimeManager:
                 binds.append(f"{DATA_VOLUME_NAME}:{DATA_VOLUME_MOUNT_IN_RUNTIME}:rw")
                 data_root = DATA_VOLUME_MOUNT_IN_RUNTIME
 
-            # Expose the filtered dstack broker to attested shared-runtime tenants.
-            binds += _attested_broker_binds(mode)
-
-            # Expose creds.sock if any project in this runtime uses broker
-            if BROKER_VOLUME_NAME and any(_project_uses_broker(p) for p in mode_projects):
-                creds_bind = f"{BROKER_VOLUME_NAME}:{BROKER_MOUNT_IN_APP}:ro"
-                if creds_bind not in binds:
-                    binds.append(creds_bind)
+            # Expose the broker to shared-runtime tenants that need it. Co-tenants
+            # here are co-trust (one V8 isolate, shared fs/env), so the broker
+            # parent is mounted whole rather than per-project.
+            if BROKER_HOST_PATH and any(_project_needs_broker(p) for p in mode_projects):
+                binds += _shared_broker_binds()
 
             # Write router with correct projects root, filtering by mode
             router_code = config["router_code"].replace("/projects/", f"{projects_root}/").replace('"/projects"', f'"{projects_root}"')
@@ -468,18 +484,11 @@ class RuntimeManager:
         binds.append(f"{proj_data_volume}:/data:rw")
         data_dir_in = "/data"
 
-        broker_binds = _attested_broker_binds(project.mode)
+        broker_binds = _project_broker_binds(project)
         binds += broker_binds
         broker_sock = f"{BROKER_MOUNT_IN_APP}/dstack.sock" if broker_binds else ""
-
-        # Add creds.sock if project uses broker handles
-        if _project_uses_broker(project) and BROKER_VOLUME_NAME:
-            creds_bind = f"{BROKER_VOLUME_NAME}:{BROKER_MOUNT_IN_APP}:ro"
-            if creds_bind not in binds:
-                binds.append(creds_bind)
-            creds_sock = f"{BROKER_MOUNT_IN_APP}/creds.sock"
-            read_paths.append(creds_sock)
-            write_paths.append(creds_sock)
+        uses_creds = _project_uses_broker(project) and bool(broker_binds)
+        creds_sock = f"{BROKER_MOUNT_IN_APP}/creds.sock" if uses_creds else ""
 
         labels = {
             "tee-proxy.managed": "true",
@@ -490,8 +499,9 @@ class RuntimeManager:
         if project.mode == "attested":
             labels["tee-daemon.attested"] = "true"
 
-        read_paths = [files_in, entry_in] + ([data_dir_in] if data_dir_in else []) + ([broker_sock] if broker_sock else [])
-        write_paths = ([data_dir_in] if data_dir_in else []) + ([broker_sock] if broker_sock else [])
+        socket_paths = [s for s in (broker_sock, creds_sock) if s]
+        read_paths = [files_in, entry_in] + ([data_dir_in] if data_dir_in else []) + socket_paths
+        write_paths = ([data_dir_in] if data_dir_in else []) + socket_paths
         cmd = [
             "deno", "run", "--no-prompt",
             f"--allow-read={','.join(read_paths)}",
@@ -511,8 +521,8 @@ class RuntimeManager:
                 env[key] = val
 
         # Inject broker socket path and token if project uses broker
-        if _project_uses_broker(project) and BROKER_VOLUME_NAME:
-            env["BROKER_SOCKET"] = f"{BROKER_MOUNT_IN_APP}/creds.sock"
+        if uses_creds:
+            env["BROKER_SOCKET"] = creds_sock
             broker_token = self._generate_broker_token(project.name)
             env["BROKER_TOKEN"] = broker_token
         cmd += [
@@ -560,13 +570,8 @@ class RuntimeManager:
             await self.docker.stop(existing)
             await self.docker.remove(existing)
             self.tracker.remove(existing)
-        binds = list(_attested_broker_binds(project.mode))
-
-        # Add creds.sock if project uses broker handles
-        if _project_uses_broker(project) and BROKER_VOLUME_NAME:
-            creds_bind = f"{BROKER_VOLUME_NAME}:{BROKER_MOUNT_IN_APP}:ro"
-            if creds_bind not in binds:
-                binds.append(creds_bind)
+        binds = list(_project_broker_binds(project))
+        uses_creds = _project_uses_broker(project) and bool(binds)
         for v in project.volumes or []:
             await self.docker.ensure_volume(v["name"])
             binds.append(f"{v['name']}:{v['mount']}")
@@ -584,7 +589,7 @@ class RuntimeManager:
                 env.append(f"{key}={val}")
 
         # Inject broker socket path and token if project uses broker
-        if _project_uses_broker(project) and BROKER_VOLUME_NAME:
+        if uses_creds:
             env.append(f"BROKER_SOCKET={BROKER_MOUNT_IN_APP}/creds.sock")
             broker_token = self._generate_broker_token(project.name)
             env.append(f"BROKER_TOKEN={broker_token}")
@@ -621,6 +626,20 @@ class RuntimeManager:
     def set_broker_store(self, broker_store):
         """Set the broker store (called by main.py after init)."""
         self.broker_store = broker_store
+
+    def set_broker_proxy_manager(self, mgr):
+        """Set the per-project dstack proxy manager (called by main.py after init)."""
+        self.broker_proxy_manager = mgr
+
+    async def ensure_project_broker(self, name: str):
+        """Create this project's per-project broker sockets (idempotent)."""
+        if self.broker_proxy_manager:
+            await self.broker_proxy_manager.ensure(name)
+
+    async def remove_project_broker(self, name: str):
+        """Tear down this project's per-project broker sockets."""
+        if self.broker_proxy_manager:
+            await self.broker_proxy_manager.remove(name)
 
     def get_broker_project(self, token: str) -> str | None:
         """Get the project name for a broker token, or None if invalid."""

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -1019,6 +1019,175 @@ def test_tier0_source_binding_survives_promote():
     print(f"  audit recorded deploy+promote: {actions} ✓")
 
 
+def test_dstack_proxy_project_scoped():
+    """Issue #80/#7: GetKey must derive the key path from the proxy's bound
+    project_id (never a caller-supplied path), and reject traversal-shaped names.
+
+    Mirrors the operator's vulnerable->fixed demo: an own-project key is derived
+    correctly, and a cross-project `path` cannot redirect derivation.
+    """
+    import asyncio
+    import shutil
+    import aiohttp
+    from aiohttp import web
+    from proxy.dstack_proxy import DstackProxy
+
+    print("\n--- Test: dstack GetKey scoped to bound project (#80) ---")
+
+    async def fake_upstream(request):
+        # Echo the (possibly rewritten) body so the test sees what path the proxy
+        # actually forwarded to dstack.
+        body = await request.read()
+        return web.Response(body=body, content_type="application/json")
+
+    async def run():
+        tmp = tempfile.mkdtemp(prefix="dstack-proxy-test-")
+        try:
+            upstream_sock = os.path.join(tmp, "upstream.sock")
+            up_app = web.Application()
+            up_app.router.add_route("*", "/{path:.*}", fake_upstream)
+            up_runner = web.AppRunner(up_app)
+            await up_runner.setup()
+            await web.UnixSite(up_runner, upstream_sock).start()
+
+            proxy = DstackProxy(upstream_sock, "projA")
+            px_app = web.Application()
+            px_app.router.add_route("*", "/{path:.*}", proxy.handle)
+            px_runner = web.AppRunner(px_app)
+            await px_runner.setup()
+            client_sock = os.path.join(tmp, "proxy.sock")
+            await web.UnixSite(px_runner, client_sock).start()
+
+            conn = aiohttp.UnixConnector(path=client_sock)
+            async with aiohttp.ClientSession(connector=conn) as s:
+                # own-key derives projA/master
+                async with s.post("http://localhost/GetKey", json={"name": "master"}) as r:
+                    assert r.status == 200, r.status
+                    assert (await r.json())["path"] == "/tee-daemon/projects/projA/master"
+                # legacy cross-project path is IGNORED -> still projA/master
+                async with s.post("http://localhost/GetKey", json={
+                    "name": "master",
+                    "path": "/tee-daemon/projects/projB/secret",
+                }) as r:
+                    assert r.status == 200, r.status
+                    assert (await r.json())["path"] == "/tee-daemon/projects/projA/master"
+                # bad names rejected (traversal / empty / leading dot)
+                for bad in ["", "../x", "a/b", "a\\b", ".hidden", "a..b"]:
+                    async with s.post("http://localhost/GetKey", json={"name": bad}) as r:
+                        assert r.status == 400, (bad, r.status)
+                # a different project's proxy derives its OWN key (no cross-talk)
+                proxyB = DstackProxy(upstream_sock, "projB")
+                b_app = web.Application()
+                b_app.router.add_route("*", "/{path:.*}", proxyB.handle)
+                b_runner = web.AppRunner(b_app)
+                await b_runner.setup()
+                b_sock = os.path.join(tmp, "proxyB.sock")
+                await web.UnixSite(b_runner, b_sock).start()
+                bconn = aiohttp.UnixConnector(path=b_sock)
+                async with aiohttp.ClientSession(connector=bconn) as s2:
+                    async with s2.post("http://localhost/GetKey", json={"name": "master"}) as r:
+                        assert (await r.json())["path"] == "/tee-daemon/projects/projB/master"
+                await b_runner.cleanup()
+                # non-GetKey methods still pass through (no name required)
+                async with s.post("http://localhost/Info", json={}) as r:
+                    assert r.status == 200, r.status
+                # disallowed method denied
+                async with s.post("http://localhost/RawSign", json={}) as r:
+                    assert r.status == 403, r.status
+            await px_runner.cleanup()
+            await up_runner.cleanup()
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    asyncio.run(run())
+    print("  project-scoped GetKey derivation OK ✓")
+
+
+def test_dstack_proxy_manager_per_project():
+    """Issue #80: DstackProxyManager serves one project-scoped socket per project
+    (dstack.sock + creds.sock in each project's own subdir), so a project's
+    container can be given only its own broker dir."""
+    import asyncio
+    import shutil
+    import aiohttp
+    from aiohttp import web
+    from proxy.dstack_proxy import DstackProxyManager
+
+    print("\n--- Test: DstackProxyManager per-project sockets (#80) ---")
+
+    async def fake_upstream(request):
+        body = await request.read()
+        return web.Response(body=body, content_type="application/json")
+
+    async def creds_handler(request):
+        # Stand-in for BrokerProxy: token-auth is irrelevant here; we only verify
+        # the SAME runner is reachable on every project's creds.sock.
+        return web.json_response({"ok": True})
+
+    async def run():
+        tmp = tempfile.mkdtemp(prefix="dstack-mgr-test-")
+        broker_dir = os.path.join(tmp, "broker")
+        os.makedirs(broker_dir)
+        try:
+            upstream_sock = os.path.join(tmp, "upstream.sock")
+            up_app = web.Application()
+            up_app.router.add_route("*", "/{path:.*}", fake_upstream)
+            up_runner = web.AppRunner(up_app)
+            await up_runner.setup()
+            await web.UnixSite(up_runner, upstream_sock).start()
+
+            creds_app = web.Application()
+            creds_app.router.add_route("*", "/{path:.*}", creds_handler)
+            creds_runner = web.AppRunner(creds_app)
+            await creds_runner.setup()
+
+            mgr = DstackProxyManager(upstream_sock, broker_dir, creds_runner)
+            await mgr.ensure("projA")
+            await mgr.ensure("projB")
+
+            # Each project got its OWN dstack.sock + creds.sock in its own subdir.
+            for p in ("projA", "projB"):
+                assert os.path.exists(os.path.join(broker_dir, p, "dstack.sock"))
+                assert os.path.exists(os.path.join(broker_dir, p, "creds.sock"))
+
+            async def getkey(project, name):
+                conn = aiohttp.UnixConnector(path=os.path.join(broker_dir, project, "dstack.sock"))
+                async with aiohttp.ClientSession(connector=conn) as s:
+                    async with s.post("http://localhost/GetKey", json={"name": name}) as r:
+                        return r.status, (await r.json()).get("path")
+
+            # projA's socket derives projA's key; projB's derives projB's — no cross-talk.
+            st, path = await getkey("projA", "master")
+            assert st == 200 and path == "/tee-daemon/projects/projA/master", (st, path)
+            st, path = await getkey("projB", "master")
+            assert st == 200 and path == "/tee-daemon/projects/projB/master", (st, path)
+
+            # The shared creds runner is reachable on BOTH project sockets.
+            for p in ("projA", "projB"):
+                conn = aiohttp.UnixConnector(path=os.path.join(broker_dir, p, "creds.sock"))
+                async with aiohttp.ClientSession(connector=conn) as s:
+                    async with s.post("http://localhost/proxy/g-x", json={}) as r:
+                        assert r.status == 200, (p, r.status)
+                        assert (await r.json()) == {"ok": True}
+
+            # ensure is idempotent; remove tears the project's sockets down.
+            await mgr.ensure("projA")
+            await mgr.remove("projA")
+            assert not os.path.exists(os.path.join(broker_dir, "projA", "dstack.sock"))
+            assert not os.path.exists(os.path.join(broker_dir, "projA", "creds.sock"))
+            # projB unaffected by projA's removal.
+            assert os.path.exists(os.path.join(broker_dir, "projB", "dstack.sock"))
+
+            await mgr.stop_all()
+            await creds_runner.cleanup()
+            await up_runner.cleanup()
+        finally:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    asyncio.run(run())
+    print("  per-project broker sockets (dstack + creds) OK ✓")
+
+
 def await_if_needed(func, *args, **kwargs):
     """Helper to run async functions in sync context if needed."""
     import asyncio
@@ -1042,6 +1211,8 @@ def main():
     cleanup_containers()
     start_daemon()
     try:
+        test_dstack_proxy_project_scoped()
+        test_dstack_proxy_manager_per_project()
         test_auth()
         test_version()
         test_deploy_static()


### PR DESCRIPTION
## What it does
Closes the cross-tenant key-derivation flaw (#7). `GetKey` on the filtered dstack broker no longer trusts a caller-supplied `path`: each project gets its **own** broker socket served by a `DstackProxy` bound to that project's id, which derives the key path server-side as `/tee-daemon/projects/<project>/​<name>` from a `name` field. A project's container is mounted **only** its own broker subdir, so it cannot even reach another project's socket.

## What you get by merging
- A tenant for project A requesting `name=master` derives `/tee-daemon/projects/A/master`; the same call from B derives `/tee-daemon/projects/B/master` — different keys, no cross-talk.
- A tenant that sends the old `path=/tee-daemon/projects/<other>/...` **cannot** derive another project's key (the field is ignored).
- Names with `/`, `..`, `\`, or a leading `.` are rejected (400).

## Risk / what to watch — **deploy requires a compose change**
- This **changes the broker mount contract** (`BROKER_VOLUME_NAME` named volume → `BROKER_HOST_PATH` host bind). `docker-compose.yaml` is updated, but **`ship-fix.sh staging` points at `docker-compose.webhost-staging.yaml`, which is NOT in this repo and not on this box.** That staging compose **must** be updated to: (a) bind-mount a host dir at `/var/run/broker` instead of the `broker_sock` named volume, and (b) set `BROKER_HOST_PATH` to that host path. **If the image is deployed without that compose change, `BROKER_HOST_PATH` stays unset and attested apps get NO broker mount** (loud — apps fail to reach the broker; not silent, but broken). Do not merge/deploy without doing this.
- `creds.sock` (BrokerProxy) is now served per-project (same `/run/broker/creds.sock` app-facing path; token-auth unchanged). It rides the same single per-project mount.
- Shared-runtime tenants (one container, many projects) still mount the broker parent whole — those co-tenants are co-trust by construction (shared V8/fs/env), so per-project isolation is moot there; isolation is enforced for container-isolated (image / isolation:container) tenants.
- Latent bug fixed along the way: `_forward` forwarded a stale `Content-Length` once GetKey rewrites the body; now stripped so the longer body isn't truncated.

## Verification
- `test_daemon.py` suite: **GREEN** (full output at `~/paseo-batch/out/80/test.log`, ends `=== ALL TESTS PASSED ===`).
- Two new unit tests run in the suite: derivation scoping (own-key works, cross-project `path` ignored, bad names rejected, second project derives its own key) and `DstackProxyManager` (per-project `dstack.sock` + `creds.sock` in separate subdirs, shared creds runner reachable on both, idempotent `ensure`, `remove` tears down only that project).
- **Not deploy-verified.** This changes daemon startup behavior (the broker-manager path runs only when `DSTACK_SOCKET` is present, i.e. on a CVM) and per the rubric the built image should be deployed to webhost-staging and pinned via `GET /_api/version`. That step is **operator-run from this box**: ghcr push credentials and `docker-compose.webhost-staging.yaml` are not present here (box-inventory), so `ship-fix.sh staging` cannot run. The compose change above + the deploy/pin are required before this should be considered verified.

<details><summary>diff stat</summary>

```
 docker-compose.yaml   |  23 ++++---
 proxy/deploy.py       |   6 ++
 proxy/dstack_proxy.py | 119 ++++++++++++++++++++++++++++++++---
 proxy/main.py         |  76 ++++++++++------------
 proxy/runtimes.py     | 111 ++++++++++++++++++--------------
 test_daemon.py        | 171 ++++++++++++++++++++++++++++++++++++++++++++++++++
 6 files changed, 397 insertions(+), 109 deletions(-)
```
</details>
