### PR TITLE
RFC 0032: capability storage module (caps/) — staging-green, report inside

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,3 +53,20 @@ End-to-end tests: `test_daemon.py`.
 - **Never commit credentials.** No `deploy/` dir, no tokens, no `.env*`. This repo is public.
 - One branch per machine; never force-push or touch another machine's branch. Push only when
   explicitly asked. (See SETUP-ZED.md for the convention.)
+)
+
+## Definition of Done for delegated work (review = read a report, not a diff)
+
+A task is NOT reviewable until all of these exist. Do not ask a human to review without them:
+
+1. **Deployed to staging** (webhost-staging daemon, `POST /_api/projects`). If you cannot
+   deploy (no token — deploy tokens live only on the operator's laptop), say so explicitly
+   and hand off to the orchestrator for the deploy+report step; do not skip to "please review".
+2. **Acceptance suite green against the staging URL** — the RFC's numbered criteria run
+   remotely, with explicit SKIP-notices for anything unreachable over HTTP. Exit-code semantics.
+3. **A published report page** on staging (static app, single self-contained HTML) stating:
+   why merge (pass/fail table), what you get (one paragraph), live endpoint samples,
+   reviewer checklist + known deferred items. Example: `caps-accept-report` (RFC 0032).
+
+The human reviews the report and the merge into main/prod — never raw work-in-progress.
+Prod deploys always remain human-directed.

--- a/caps/Dockerfile
+++ b/caps/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:22-slim
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY index.mjs demo-server.mjs accept.mjs test.mjs ./
+EXPOSE 3500
+CMD ["node", "--experimental-wasm-modules", "demo-server.mjs"]

--- a/caps/accept.mjs
+++ b/caps/accept.mjs
@@ -1,0 +1,369 @@
+import { Biscuit, KeyPair, PublicKey, SignatureAlgorithm, block } from "@biscuit-auth/biscuit-wasm";
+import { Delegation, delegate as ucanDelegate, invoke } from "@ucanto/core";
+import { ed25519 } from "@ucanto/principal";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createCaps, CapsAuthorizationError } from "./index.mjs";
+
+class Skip extends Error {
+  constructor(message, value) {
+    super(message);
+    this.value = value;
+  }
+}
+
+const remoteUrl = parseUrl(process.argv);
+const runner = remoteUrl ? await remoteRunner(remoteUrl) : await localRunner();
+const results = [];
+const minted = [];
+const revokedIds = new Set();
+
+try {
+  await criterion(1, "roundtrip", roundtrip);
+  await criterion(2, "link-claim read", linkClaimRead);
+  await criterion(3, "attenuation refusal", attenuationRefusal);
+  await criterion(4, "scope refusal", scopeRefusal);
+  await criterion(5, "section scoping", sectionScoping);
+  await criterion(6, "wrong-key/stranger", ucanWrongKeyRefusal);
+  await criterion(7, "expiry", expiryRefusal);
+  const revoked = await criterion(8, "revocation", revocation);
+  await criterion(9, "inventory", inventory);
+  await criterion(10, "persistence", () => persistence(revoked));
+} finally {
+  await runner.close?.();
+}
+
+for (const result of results) {
+  const suffix = result.notice ? ` - ${result.notice}` : "";
+  console.log(`${result.status} ${result.id}. ${result.name}${suffix}`);
+}
+
+const failed = results.filter(r => r.status === "FAIL");
+const skipped = results.filter(r => r.status === "SKIP");
+console.log(`${failed.length ? "FAIL" : "PASS"} ${results.length - failed.length - skipped.length} passed, ${skipped.length} skipped, ${failed.length} failed`);
+if (failed.length) process.exitCode = 1;
+
+async function criterion(id, name, fn) {
+  const start = performance.now();
+  try {
+    const value = await fn();
+    results.push({ id, name, status: "PASS", notice: `${Math.round(performance.now() - start)}ms` });
+    return value;
+  } catch (e) {
+    if (e instanceof Skip) {
+      results.push({ id, name, status: "SKIP", notice: e.message });
+      return e.value;
+    }
+    results.push({ id, name, status: "FAIL", notice: e.stack ?? e.message });
+    process.exitCode = 1;
+  }
+}
+
+async function roundtrip() {
+  const { token } = await mint({ path: "repo/", ops: ["read", "write"], expiry: future() });
+  await runner.write(token, "repo/A/x", Buffer.from("roundtrip"));
+  assert.equal((await runner.read(token, "repo/A/x")).toString(), "roundtrip");
+}
+
+async function linkClaimRead() {
+  const { token } = await mint({ path: "repo/A/", ops: ["read"], expiry: future() });
+  assert.deepEqual(await runner.verify(token, { path: "repo/A/x", op: "read" }), { ok: true });
+  assert.equal((await runner.claim(token, "repo/A/x")).toString(), "roundtrip");
+}
+
+async function attenuationRefusal() {
+  const { token } = await mint({ path: "repo/A/", ops: ["read"], expiry: future() });
+  const refused = await runner.verify(token, { path: "repo/A/x", op: "write" });
+  assert.equal(refused.ok, false);
+  const write = await runner.writeRefused(token, "repo/A/x", Buffer.from("denied"));
+  assert.equal(write.status, 403);
+}
+
+async function scopeRefusal() {
+  const { token } = await mint({ path: "repo/A/", ops: ["read"], expiry: future() });
+  const refused = await runner.verify(token, { path: "repo/B/y", op: "read" });
+  assert.equal(refused.ok, false);
+  const read = await runner.readRefused(token, "repo/B/y");
+  assert.equal(read.status, 403);
+}
+
+async function sectionScoping() {
+  const owner = (await mint({ path: "repo/", ops: ["read", "write"], expiry: future() })).token;
+  await runner.write(owner, "repo/F/s2-security/body", Buffer.from("section 2"));
+  await runner.write(owner, "repo/F/_full", Buffer.from("full file"));
+
+  const { token } = await mint({ path: "repo/F/s2-security/", ops: ["read"], expiry: future() });
+  assert.equal((await runner.read(token, "repo/F/s2-security/body")).toString(), "section 2");
+  assert.equal((await runner.verify(token, { path: "repo/F/_full", op: "read" })).ok, false);
+  assert.equal((await runner.readRefused(token, "repo/F/_full")).status, 403);
+}
+
+async function ucanWrongKeyRefusal() {
+  const alice = await ed25519.generate();
+  const mallory = await ed25519.generate();
+  const { delegation } = await delegate({ toDID: alice.did(), path: "repo/A/", ops: ["read"], expiry: future() });
+  const refused = await runner.ucanVerify({ delegation, signer: mallory, path: "repo/A/x", op: "read" });
+  assert.equal(refused.ok, false);
+}
+
+async function expiryRefusal() {
+  const { token } = await mint({ path: "repo/", ops: ["read"], expiry: past() });
+  assert.equal((await runner.verify(token, { path: "repo/A/x", op: "read" })).ok, false);
+  assert.equal((await runner.readRefused(token, "repo/A/x")).status, 403);
+}
+
+async function revocation() {
+  const { token, id } = await mint({ path: "repo/A/", ops: ["read"], expiry: future() });
+  const descendant = await runner.attenuate(token, "repo/A/x");
+
+  assert.deepEqual(await runner.verify(token, { path: "repo/A/x", op: "read" }), { ok: true });
+  assert.deepEqual(await runner.verify(descendant, { path: "repo/A/x", op: "read" }), { ok: true });
+
+  await runner.revoke(id);
+  revokedIds.add(id);
+
+  assert.deepEqual(await runner.verify(token, { path: "repo/A/x", op: "read" }), { ok: false, code: "REVOKED" });
+  assert.deepEqual(await runner.verify(descendant, { path: "repo/A/x", op: "read" }), { ok: false, code: "REVOKED" });
+  assert.equal((await runner.readRefused(token, "repo/A/x")).status, 403);
+  assert.equal((await runner.readRefused(descendant, "repo/A/x")).status, 403);
+
+  return { id, token, descendant };
+}
+
+async function inventory() {
+  const grants = await runner.grants();
+  for (const issued of minted) {
+    const grant = grants.find(g => g.id === issued.id);
+    assert.ok(grant, `missing grant ${issued.id}`);
+    assert.equal(grant.path, issued.path);
+    assert.deepEqual(grant.ops, issued.ops);
+    assert.equal(grant.expiry, issued.expiry);
+    assert.equal(grant.revoked, revokedIds.has(grant.id));
+  }
+}
+
+async function persistence(revoked) {
+  if (!runner.reopen) throw new Skip("remote mode cannot restart the deployed process; verify by restarting demo-server with the same DATA_DIR/ROOT_KEY");
+  const reopened = await runner.reopen();
+  assert.deepEqual(await reopened.verify(revoked.token, { path: "repo/A/x", op: "read" }), { ok: false, code: "REVOKED" });
+  assert.deepEqual(await reopened.verify(revoked.descendant, { path: "repo/A/x", op: "read" }), { ok: false, code: "REVOKED" });
+  const persisted = await reopened.grants();
+  assert.ok(persisted.find(g => g.id === revoked.id)?.revoked);
+  await reopened.close?.();
+}
+
+async function localRunner() {
+  const root = new KeyPair();
+  const dataDir = await mkdtemp(join(tmpdir(), "caps-accept-"));
+  const rootKey = root.getPrivateKey().toString();
+  const caps = createCaps({ dataDir, rootKey });
+  return localAdapter({ caps, root, dataDir, rootKey, cleanup: true });
+}
+
+function localAdapter({ caps, root, dataDir, rootKey, cleanup }) {
+  return {
+    async mint(args) {
+      return caps.mint(args);
+    },
+    async delegate(args) {
+      return caps.delegate(args);
+    },
+    async verify(token, args) {
+      return caps.verify(token, args);
+    },
+    async ucanVerify({ delegation, signer, path, op }) {
+      return caps.verify(await invocation({ delegation, signer, path, op }), { path, op });
+    },
+    async read(token, path) {
+      return await caps.read(token, path);
+    },
+    async claim(token, path) {
+      return await caps.read(token, path);
+    },
+    async readRefused(token, path) {
+      try {
+        await caps.read(token, path);
+        return { status: 200 };
+      } catch (e) {
+        if (e instanceof CapsAuthorizationError) return { status: 403, body: { ok: false, code: e.code } };
+        throw e;
+      }
+    },
+    async write(token, path, bytes) {
+      await caps.write(token, path, bytes);
+    },
+    async writeRefused(token, path, bytes) {
+      try {
+        await caps.write(token, path, bytes);
+        return { status: 200 };
+      } catch (e) {
+        if (e instanceof CapsAuthorizationError) return { status: 403, body: { ok: false, code: e.code } };
+        throw e;
+      }
+    },
+    async attenuate(token, capPath) {
+      return Biscuit.fromBase64(token, root.getPublicKey())
+        .appendBlock(block`check if resource($p), $p.starts_with(${capPath});`)
+        .toBase64();
+    },
+    async revoke(id) {
+      caps.revoke(id);
+    },
+    async grants() {
+      return caps.grants();
+    },
+    async reopen() {
+      return localAdapter({ caps: createCaps({ dataDir, rootKey }), root, dataDir, rootKey, cleanup: false });
+    },
+    async close() {
+      if (cleanup) await rm(dataDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function remoteRunner(rawUrl) {
+  const base = rawUrl.replace(/\/+$/, "");
+  const health = await getJson(`${base}/healthz`);
+  if (!health.ok || !health.publicKey) throw new Error(`remote health failed: ${JSON.stringify(health)}`);
+  const publicKey = PublicKey.fromString(health.publicKey.replace(/^ed25519\//, ""), SignatureAlgorithm.Ed25519);
+
+  return {
+    async mint(args) {
+      return await postJson(`${base}/mint`, args);
+    },
+    async delegate(args) {
+      const issued = await postJson(`${base}/delegate`, args);
+      return { id: issued.id, delegation: Buffer.from(issued.delegation, "base64") };
+    },
+    async verify(token, args) {
+      return await postJson(`${base}/verify`, { credential: token, ...args });
+    },
+    async ucanVerify({ delegation, signer, path, op }) {
+      return await postJson(`${base}/ucan/verify`, {
+        delegation: Buffer.from(delegation).toString("base64"),
+        signer: encodeSigner(signer),
+        path,
+        op,
+      });
+    },
+    async read(token, path) {
+      const result = await postJson(`${base}/read`, { credential: token, path });
+      return Buffer.from(result.content, "base64");
+    },
+    async claim(token, path) {
+      const result = await postJson(`${base}/claim`, { credential: token, path });
+      return Buffer.from(result.content, "base64");
+    },
+    async readRefused(token, path) {
+      return await postStatus(`${base}/read`, { credential: token, path });
+    },
+    async write(token, path, bytes) {
+      await postJson(`${base}/write`, { credential: token, path, content: Buffer.from(bytes).toString("base64") });
+    },
+    async writeRefused(token, path, bytes) {
+      return await postStatus(`${base}/write`, { credential: token, path, content: Buffer.from(bytes).toString("base64") });
+    },
+    async attenuate(token, capPath) {
+      return Biscuit.fromBase64(token, publicKey)
+        .appendBlock(block`check if resource($p), $p.starts_with(${capPath});`)
+        .toBase64();
+    },
+    async revoke(id) {
+      await postJson(`${base}/revoke`, { id });
+    },
+    async grants() {
+      return (await getJson(`${base}/grants`)).grants;
+    },
+  };
+}
+
+async function mint(args) {
+  const issued = await runner.mint(args);
+  minted.push({
+    id: issued.id,
+    path: args.path,
+    ops: [...new Set(args.ops)],
+    expiry: new Date(args.expiry).toISOString(),
+  });
+  return issued;
+}
+
+async function delegate(args) {
+  const issued = await runner.delegate(args);
+  minted.push({
+    id: issued.id,
+    path: args.path,
+    ops: [...new Set(args.ops)],
+    expiry: new Date(args.expiry).toISOString(),
+  });
+  return issued;
+}
+
+async function invocation({ delegation, signer, path, op }) {
+  const extracted = (await Delegation.extract(delegation)).ok;
+  assert.ok(extracted);
+  return invoke({
+    issuer: signer,
+    audience: { did: () => extracted.capabilities[0].with },
+    proofs: [extracted],
+    capability: { can: `file/${op}`, with: extracted.capabilities[0].with, nb: { path } },
+  });
+}
+
+function encodeSigner(signer) {
+  const archive = signer.toArchive();
+  return {
+    id: archive.id,
+    keys: Object.fromEntries(Object.entries(archive.keys).map(([id, bytes]) => [id, Buffer.from(bytes).toString("base64")])),
+  };
+}
+
+async function postJson(url, payload) {
+  const res = await fetch(url, jsonRequest(payload));
+  const json = await res.json();
+  if (!res.ok) throw new Error(`${url} returned ${res.status}: ${JSON.stringify(json)}`);
+  return json;
+}
+
+async function postStatus(url, payload) {
+  const res = await fetch(url, jsonRequest(payload));
+  let body;
+  try {
+    body = await res.json();
+  } catch {
+    body = await res.text();
+  }
+  return { status: res.status, body };
+}
+
+async function getJson(url) {
+  const res = await fetch(url);
+  const json = await res.json();
+  if (!res.ok) throw new Error(`${url} returned ${res.status}: ${JSON.stringify(json)}`);
+  return json;
+}
+
+function jsonRequest(payload) {
+  return {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(payload),
+  };
+}
+
+function parseUrl(args) {
+  const index = args.indexOf("--url");
+  if (index === -1) return null;
+  if (!args[index + 1]) throw new Error("--url requires a value");
+  return args[index + 1];
+}
+
+function future() {
+  return new Date(Date.now() + 3600_000);
+}
+
+function past() {
+  return new Date(Date.now() - 3600_000);
+}

--- a/caps/demo-server.mjs
+++ b/caps/demo-server.mjs
@@ -1,0 +1,126 @@
+import { KeyPair, PrivateKey } from "@biscuit-auth/biscuit-wasm";
+import { Delegation, invoke } from "@ucanto/core";
+import { ed25519 } from "@ucanto/principal";
+import http from "node:http";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { createCaps, CapsAuthorizationError } from "./index.mjs";
+
+const PORT = Number(process.env.PORT || 3500);
+const DATA_DIR = resolve(process.env.DATA_DIR || "./data");
+const ROOT_KEY_FILE = join(DATA_DIR, "root.key");
+
+await mkdir(DATA_DIR, { recursive: true });
+const rootKey = loadRootKey();
+const root = KeyPair.fromPrivateKey(PrivateKey.fromString(rootKey));
+const caps = createCaps({ dataDir: DATA_DIR, rootKey });
+
+http.createServer((req, res) => {
+  handle(req, res).catch(e => json(res, 500, { ok: false, error: e.message }));
+}).listen(PORT, () => {
+  console.log(`caps demo server listening on :${PORT}`);
+});
+
+async function handle(req, res) {
+  const url = new URL(req.url, `http://${req.headers.host || "localhost"}`);
+  const path = url.pathname.replace(/\/+$/, "") || "/";
+
+  if (req.method === "GET" && path === "/healthz") {
+    return json(res, 200, { ok: true, publicKey: root.getPublicKey().toString() });
+  }
+  if (req.method === "POST" && path === "/mint") {
+    return json(res, 200, { ok: true, ...(caps.mint(await body(req))) });
+  }
+  if (req.method === "POST" && path === "/delegate") {
+    const issued = await caps.delegate(await body(req));
+    return json(res, 200, { ok: true, id: issued.id, delegation: b64(issued.delegation) });
+  }
+  if (req.method === "POST" && path === "/verify") {
+    const { credential, path: capPath, op } = await body(req);
+    return json(res, 200, await caps.verify(decodeCredential(credential), { path: capPath, op }));
+  }
+  if (req.method === "POST" && path === "/ucan/verify") {
+    const { delegation, signer, path: capPath, op } = await body(req);
+    const credential = await ucanInvocation({ delegation, signer, path: capPath, op });
+    return json(res, 200, await caps.verify(credential, { path: capPath, op }));
+  }
+  if (req.method === "POST" && (path === "/read" || path === "/claim")) {
+    const { credential, path: capPath } = await body(req);
+    try {
+      const bytes = await caps.read(decodeCredential(credential), capPath);
+      return json(res, 200, { ok: true, content: bytes.toString("base64") });
+    } catch (e) {
+      if (e instanceof CapsAuthorizationError) return json(res, 403, { ok: false, code: e.code });
+      throw e;
+    }
+  }
+  if (req.method === "POST" && path === "/write") {
+    const { credential, path: capPath, content } = await body(req);
+    try {
+      await caps.write(decodeCredential(credential), capPath, Buffer.from(content, "base64"));
+      return json(res, 200, { ok: true });
+    } catch (e) {
+      if (e instanceof CapsAuthorizationError) return json(res, 403, { ok: false, code: e.code });
+      throw e;
+    }
+  }
+  if (req.method === "POST" && path === "/revoke") {
+    const { id } = await body(req);
+    caps.revoke(id);
+    return json(res, 200, { ok: true });
+  }
+  if (req.method === "GET" && path === "/grants") {
+    return json(res, 200, { ok: true, grants: caps.grants() });
+  }
+  return json(res, 404, { ok: false, error: "not found" });
+}
+
+function loadRootKey() {
+  if (process.env.ROOT_KEY) return process.env.ROOT_KEY;
+  if (existsSync(ROOT_KEY_FILE)) return readFileSync(ROOT_KEY_FILE, "utf8").trim();
+  const key = new KeyPair().getPrivateKey().toString();
+  mkdirSync(dirname(ROOT_KEY_FILE), { recursive: true });
+  writeFileSync(ROOT_KEY_FILE, `${key}\n`, { mode: 0o600 });
+  return key;
+}
+
+async function ucanInvocation({ delegation, signer, path, op }) {
+  const extracted = await Delegation.extract(Buffer.from(delegation, "base64"));
+  if (!extracted.ok) throw new Error(`UCAN extract failed: ${extracted.error?.message ?? extracted.error}`);
+  const issuer = ed25519.from(decodeSigner(signer));
+  return invoke({
+    issuer,
+    audience: { did: () => extracted.ok.capabilities[0].with },
+    proofs: [extracted.ok],
+    capability: { can: `file/${op}`, with: extracted.ok.capabilities[0].with, nb: { path } },
+  });
+}
+
+function decodeCredential(credential) {
+  if (credential?.type === "ucan") return Buffer.from(credential.value, "base64");
+  return credential?.value ?? credential;
+}
+
+function decodeSigner(archive) {
+  return {
+    id: archive.id,
+    keys: Object.fromEntries(Object.entries(archive.keys).map(([id, bytes]) => [id, Buffer.from(bytes, "base64")])),
+  };
+}
+
+async function body(req) {
+  const chunks = [];
+  for await (const chunk of req) chunks.push(chunk);
+  if (chunks.length === 0) return {};
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function json(res, status, payload) {
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(payload));
+}
+
+function b64(bytes) {
+  return Buffer.from(bytes).toString("base64");
+}

--- a/caps/index.mjs
+++ b/caps/index.mjs
@@ -1,0 +1,314 @@
+import { biscuit, authorizer, Biscuit, KeyPair, PrivateKey } from "@biscuit-auth/biscuit-wasm";
+import * as Server from "@ucanto/server";
+import { Absentee, ed25519 } from "@ucanto/principal";
+import { Delegation, delegate as ucanDelegate } from "@ucanto/core";
+import * as Client from "@ucanto/client";
+import * as CAR from "@ucanto/transport/car";
+import { Authorization } from "@ucanto/validator";
+import { capability, Schema, ok, error, provide } from "@ucanto/server";
+import { DatabaseSync } from "node:sqlite";
+import { mkdirSync } from "node:fs";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, isAbsolute, join, resolve } from "node:path";
+
+const LIMITS = { max_facts: 1000n, max_iterations: 100n, max_time_micro: 5_000_000n };
+const OPS = new Set(["read", "write"]);
+const UCAN_SERVICE_KEY = "ucan_service_key";
+
+const pathAttenuates = (claim, proof) => {
+  if (claim.with !== proof.with) return error(`resource ${claim.with} != delegated ${proof.with}`);
+  const prefix = proof.nb.path;
+  if (!claim.nb.path.startsWith(prefix)) return error(`path ${claim.nb.path} escapes delegated prefix ${prefix}`);
+  return ok({});
+};
+
+const FileRead = capability({
+  can: "file/read",
+  with: Schema.URI.match({ protocol: "did:" }),
+  nb: Schema.struct({ path: Schema.string() }),
+  derives: pathAttenuates,
+});
+
+const FileWrite = capability({
+  can: "file/write",
+  with: Schema.URI.match({ protocol: "did:" }),
+  nb: Schema.struct({ path: Schema.string(), content: Schema.string().optional() }),
+  derives: pathAttenuates,
+});
+
+export function createCaps({ dataDir, rootKey, db } = {}) {
+  if (!dataDir) throw new Error("createCaps requires dataDir");
+  if (!rootKey) throw new Error("createCaps requires rootKey");
+  if (db !== undefined) throw new Error("createCaps stores caps state at dataDir/caps.db");
+
+  const rootDir = resolve(dataDir);
+  mkdirSync(rootDir, { recursive: true });
+  const store = new DatabaseSync(join(rootDir, "caps.db"));
+  const root = KeyPair.fromPrivateKey(PrivateKey.fromString(rootKey));
+  initDb(store);
+  const serviceSigner = loadServiceSigner(store);
+
+  const insertGrant = store.prepare(`
+    INSERT INTO grants (id, path, ops, expiry)
+    VALUES (?, ?, ?, ?)
+  `);
+  const listGrants = store.prepare(`
+    SELECT grants.id, grants.path, grants.ops, grants.expiry, revoked_biscuit_ids.id IS NOT NULL AS revoked
+    FROM grants
+    LEFT JOIN revoked_biscuit_ids ON revoked_biscuit_ids.id = grants.id
+    ORDER BY grants.issued_at, grants.rowid
+  `);
+  const insertRevocation = store.prepare(`
+    INSERT OR IGNORE INTO revoked_biscuit_ids (id)
+    VALUES (?)
+  `);
+  const findRevocation = store.prepare(`
+    SELECT 1 FROM revoked_biscuit_ids WHERE id = ? LIMIT 1
+  `);
+
+  function mint({ path, ops, expiry }) {
+    assertPath(path);
+    const rights = assertOps(ops);
+    const exp = new Date(expiry);
+    if (Number.isNaN(exp.getTime())) throw new Error("mint expiry must be a valid Date or date string");
+
+    const built = (rights.has("read") && rights.has("write")
+      ? biscuit`right("read"); right("write"); check if resource($p), $p.starts_with(${path}); check if time($t), $t < ${exp};`
+      : rights.has("write")
+      ? biscuit`right("write"); check if resource($p), $p.starts_with(${path}); check if time($t), $t < ${exp};`
+      : biscuit`right("read"); check if resource($p), $p.starts_with(${path}); check if time($t), $t < ${exp};`
+    ).build(root.getPrivateKey());
+
+    const id = revocationIdentifiers(built)[0];
+    insertGrant.run(id, path, JSON.stringify([...rights]), exp.toISOString());
+    return { token: built.toBase64(), id };
+  }
+
+  async function delegate({ toDID, path, ops, expiry }) {
+    assertDID(toDID);
+    assertPath(path);
+    const rights = assertOps(ops);
+    const exp = new Date(expiry);
+    if (Number.isNaN(exp.getTime())) throw new Error("delegate expiry must be a valid Date or date string");
+
+    const service = await serviceSigner;
+    const delegation = await ucanDelegate({
+      issuer: service,
+      audience: Absentee.from({ id: toDID }),
+      capabilities: [...rights].map(op => ({ can: ucanCan(op), with: service.did(), nb: { path } })),
+      expiration: Math.floor(exp.getTime() / 1000),
+    });
+    const archived = await delegation.archive();
+    if (!archived.ok) throw new Error(`UCAN archive failed: ${archived.error?.message ?? archived.error}`);
+
+    const id = delegation.cid.toString();
+    insertGrant.run(id, path, JSON.stringify([...rights]), exp.toISOString());
+    return { delegation: archived.ok, id };
+  }
+
+  function verify(credential, { path, op }) {
+    if (isUcanCredential(credential)) return verifyUcan(credential, { path, op });
+
+    let t;
+    try {
+      assertPath(path);
+      assertOp(op);
+      if (!credential) throw new Error("missing credential");
+      t = Biscuit.fromBase64(credential, root.getPublicKey());
+    } catch (e) {
+      return { ok: false, code: errorCode(e) };
+    }
+
+    const revoked = revocationIdentifiers(t).find(id => findRevocation.get(id));
+    if (revoked) return { ok: false, code: "REVOKED" };
+
+    try {
+      authorizer`
+        resource(${path});
+        operation(${op});
+        time(${new Date()});
+        allow if right(${op});
+      `.buildAuthenticated(t).authorizeWithLimits(LIMITS);
+      return { ok: true };
+    } catch (e) {
+      return { ok: false, code: errorCode(e) };
+    }
+  }
+
+  async function verifyUcan(credential, { path, op }) {
+    try {
+      assertPath(path);
+      assertOp(op);
+      const invocation = await extractInvocation(credential);
+      assertInvocationMatches(invocation, { path, op });
+      const service = await serviceSigner;
+      const server = makeUcanServer(service, findRevocation);
+      const conn = Client.connect({ id: service, codec: CAR.outbound, channel: server });
+      const result = await invocation.execute(conn);
+      if (result.out?.ok) return { ok: true };
+      return { ok: false, code: errorCode(result.out?.error ?? result) };
+    } catch (e) {
+      return { ok: false, code: errorCode(e) };
+    }
+  }
+
+  function revoke(id) {
+    assertRevocationId(id);
+    insertRevocation.run(id);
+  }
+
+  function grants() {
+    return listGrants.all().map(grant => ({
+      id: grant.id,
+      path: grant.path,
+      ops: JSON.parse(grant.ops),
+      expiry: grant.expiry,
+      revoked: Boolean(grant.revoked),
+    }));
+  }
+
+  async function read(credential, path) {
+    const az = await verify(credential, { path, op: "read" });
+    if (!az.ok) throw new CapsAuthorizationError("read refused", az.code);
+    return await readFile(filePath(rootDir, path));
+  }
+
+  async function write(credential, path, bytes) {
+    const az = await verify(credential, { path, op: "write" });
+    if (!az.ok) throw new CapsAuthorizationError("write refused", az.code);
+    const target = filePath(rootDir, path);
+    await mkdir(dirname(target), { recursive: true });
+    await writeFile(target, bytes);
+  }
+
+  return { mint, delegate, verify, read, write, revoke, grants };
+}
+
+export class CapsAuthorizationError extends Error {
+  constructor(message, code) {
+    super(message);
+    this.name = "CapsAuthorizationError";
+    this.code = code;
+  }
+}
+
+function assertOps(ops) {
+  if (!Array.isArray(ops) || ops.length === 0) throw new Error("mint ops must be a non-empty array");
+  const rights = new Set(ops);
+  for (const op of rights) assertOp(op);
+  return rights;
+}
+
+function assertOp(op) {
+  if (!OPS.has(op)) throw new Error(`unsupported op: ${op}`);
+}
+
+function assertPath(path) {
+  if (typeof path !== "string" || path.length === 0) throw new Error("path must be a non-empty string");
+  if (path.includes("\0")) throw new Error("path contains NUL byte");
+  if (isAbsolute(path) || path.split("/").includes("..")) throw new Error(`unsafe path: ${path}`);
+}
+
+function assertRevocationId(id) {
+  if (typeof id !== "string" || !/^([0-9a-f]+|bafy[a-z2-7]+)$/i.test(id)) {
+    throw new Error("revocation id must be a Biscuit hex id or UCAN CID");
+  }
+}
+
+function assertDID(did) {
+  if (typeof did !== "string" || !did.startsWith("did:")) throw new Error("toDID must be a DID string");
+}
+
+function initDb(store) {
+  store.exec(`
+    CREATE TABLE IF NOT EXISTS meta (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS grants (
+      id TEXT PRIMARY KEY,
+      path TEXT NOT NULL,
+      ops TEXT NOT NULL,
+      expiry TEXT NOT NULL,
+      issued_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    );
+    CREATE TABLE IF NOT EXISTS revoked_biscuit_ids (
+      id TEXT PRIMARY KEY,
+      revoked_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+    );
+  `);
+}
+
+async function loadServiceSigner(store) {
+  const getMeta = store.prepare("SELECT value FROM meta WHERE key = ? LIMIT 1");
+  const setMeta = store.prepare("INSERT INTO meta (key, value) VALUES (?, ?)");
+  const existing = getMeta.get(UCAN_SERVICE_KEY)?.value;
+  if (existing) return ed25519.decode(new Uint8Array(Buffer.from(existing, "base64url")));
+
+  const signer = await ed25519.generate();
+  setMeta.run(UCAN_SERVICE_KEY, Buffer.from(signer.encode()).toString("base64url"));
+  return signer;
+}
+
+function revocationIdentifiers(token) {
+  const ids = token.getRevocationIdentifiers();
+  if (!Array.isArray(ids) || ids.length === 0) throw new Error("Biscuit token has no revocation identifiers");
+  for (const id of ids) assertRevocationId(id);
+  return ids;
+}
+
+function filePath(rootDir, path) {
+  assertPath(path);
+  const target = resolve(rootDir, path);
+  if (target !== rootDir && !target.startsWith(`${rootDir}/`)) throw new Error(`path escapes dataDir: ${path}`);
+  return target;
+}
+
+function errorCode(e) {
+  if (e?.FailedLogic) return "CHECK_FAILED";
+  return String(e?.message ?? e).slice(0, 80);
+}
+
+function ucanCan(op) {
+  assertOp(op);
+  return `file/${op}`;
+}
+
+function makeUcanServer(serviceSigner, findRevocation) {
+  return Server.create({
+    id: serviceSigner,
+    codec: CAR.inbound,
+    service: {
+      file: {
+        read: provide(FileRead, async () => ok({})),
+        write: provide(FileWrite, async () => ok({})),
+      },
+    },
+    validateAuthorization: auth => {
+      for (const cid of Authorization.iterate(auth)) {
+        if (findRevocation.get(cid.toString())) return error({ name: "Revoked", message: `proof ${cid} revoked` });
+      }
+      return ok({});
+    },
+  });
+}
+
+function isUcanCredential(credential) {
+  return credential instanceof Uint8Array || Boolean(credential?.execute);
+}
+
+async function extractInvocation(credential) {
+  if (credential?.execute) return credential;
+  const extracted = await Delegation.extract(credential);
+  if (!extracted.ok) throw new Error(`UCAN extract failed: ${extracted.error?.message ?? extracted.error}`);
+  if (!extracted.ok.execute) throw new Error("UCAN credential must be an invocation");
+  return extracted.ok;
+}
+
+function assertInvocationMatches(invocation, { path, op }) {
+  const expectedCan = ucanCan(op);
+  const matches = invocation.capabilities?.some(cap =>
+    cap.can === expectedCan && cap.nb?.path === path
+  );
+  if (!matches) throw new Error(`UCAN invocation does not authorize ${op} ${path}`);
+}

--- a/caps/package-lock.json
+++ b/caps/package-lock.json
@@ -1,0 +1,240 @@
+{
+  "name": "@dstack-webhost/caps",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@dstack-webhost/caps",
+      "dependencies": {
+        "@biscuit-auth/biscuit-wasm": "0.6.0",
+        "@ucanto/client": "^9.0.2",
+        "@ucanto/core": "^10.4.6",
+        "@ucanto/principal": "^9.0.3",
+        "@ucanto/server": "^11.0.3",
+        "@ucanto/transport": "^9.2.1",
+        "@ucanto/validator": "^10.0.1"
+      }
+    },
+    "node_modules/@biscuit-auth/biscuit-wasm": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@biscuit-auth/biscuit-wasm/-/biscuit-wasm-0.6.0.tgz",
+      "integrity": "sha512-QM4rZU+f/WI1tr2vPMCErrGXrJdfK4mTiY1m/JyR1eIiOIJOzoHUHf3Z+hE2a1+Dt9vm6wgGyJg89S871JN7BQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/@ipld/car": {
+      "version": "5.4.6",
+      "resolved": "https://registry.npmjs.org/@ipld/car/-/car-5.4.6.tgz",
+      "integrity": "sha512-f1Iyb9ci8B/TGCyjAuSQ6BOLiy2u8en7rB+SumbyweqXDu3gxYJwYbGzoposKjOzc4CeGlkEbwEw8REoekYAKQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@ipld/dag-cbor": "^10.0.1",
+        "cborg": "^5.0.0",
+        "multiformats": "^14.0.0",
+        "varint": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@ipld/car/node_modules/@ipld/dag-cbor": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-10.0.1.tgz",
+      "integrity": "sha512-nF07iiZPqduSXyMxc0jGANArRHFa9hjMQpQlgLOV2O/3xI1CNb5sXhvbmigbMiz5owSGi0Oq10VtauupMojuiw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "cborg": "^5.0.1",
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/@ipld/car/node_modules/multiformats": {
+      "version": "14.0.4",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.4.tgz",
+      "integrity": "sha512-+SXItmOUWzT0kjlIfkZ4NawJaC9jW/mPlyn902V9Qgpc7YDwdEiwqbiZxTyvC0XWh1jZguXca3A/WQ+UOPRLUA==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@ipld/dag-cbor": {
+      "version": "9.2.7",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-cbor/-/dag-cbor-9.2.7.tgz",
+      "integrity": "sha512-ZmfXmElRWATr+hoUTSAOr6HUcjVhOcNHDqgczc76qte2DHHFEK0ZhNzUcdTDQhF/VSIvf2ioaRTRLWwLc83sNw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "cborg": "^5.0.1",
+        "multiformats": "^13.1.0"
+      }
+    },
+    "node_modules/@ipld/dag-json": {
+      "version": "10.2.9",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-json/-/dag-json-10.2.9.tgz",
+      "integrity": "sha512-opNPQQsTuCFZkaJCAqXrB/n9OqUD6W2Boz/Au5HjhLQyczmT8lxoOZObqQ5S5hhnV8p6sgKAimNhUB2W6y0Mzg==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "cborg": "^5.0.0",
+        "multiformats": "^13.1.0"
+      }
+    },
+    "node_modules/@ipld/dag-ucan": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/@ipld/dag-ucan/-/dag-ucan-3.4.5.tgz",
+      "integrity": "sha512-wiWhH0Ju7WgnumsarHCYtlo+1NRy+WIsXyAB7g2sDqVsKCyEJiLLmjeZzKqNv+qMxLnUS8bQ287cPiQ//s/oJQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-json": "^10.0.0",
+        "multiformats": "^13.3.1"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.9.7",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.7.tgz",
+      "integrity": "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.8.0"
+      },
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/ed25519": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.5.tgz",
+      "integrity": "sha512-xuS0nwRMQBvSxDa7UxMb61xTiH3MxTgUfhyPUALVIe0FlOAz4sjELwyDRyUvqeEYfRSG9qNjFIycqLZppg4RSA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@ucanto/client": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@ucanto/client/-/client-9.0.2.tgz",
+      "integrity": "sha512-XbG8rw/fc1hPSFKDQ/z1NpIuc4Lm79J4NWbP+dedvDnb5LmOBMHE8bjjEPD4xGO2eh6fWQSZ4YTYk5wjkLz+3Q==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@ucanto/core": "^10.4.5",
+        "@ucanto/interface": "^11.0.1"
+      }
+    },
+    "node_modules/@ucanto/core": {
+      "version": "10.4.6",
+      "resolved": "https://registry.npmjs.org/@ucanto/core/-/core-10.4.6.tgz",
+      "integrity": "sha512-K3aRsbolL3Mas1P+7Ba+kpCvEVlBJf93V4OZ23FOZRBnbodD+x/ygOEXWL8OYcZpBwYiPeYWMAJPZpIzjNIEoQ==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@ipld/car": "^5.1.0",
+        "@ipld/dag-cbor": "^9.0.0",
+        "@ipld/dag-ucan": "^3.4.5",
+        "@ucanto/interface": "^11.0.1",
+        "multiformats": "^13.3.1"
+      }
+    },
+    "node_modules/@ucanto/interface": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/@ucanto/interface/-/interface-11.0.1.tgz",
+      "integrity": "sha512-d0yoPFXdbb3EyM3sBom5VVcVyz58HT+57qi/ywSY1dbZAm4c7GZss0lpfcI5OXQREzGCzJYAg1e7pFwqbATnmQ==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@ipld/dag-ucan": "^3.4.5",
+        "multiformats": "^13.3.1"
+      }
+    },
+    "node_modules/@ucanto/principal": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@ucanto/principal/-/principal-9.0.3.tgz",
+      "integrity": "sha512-MFLvckOpQA46VSeLWyB7xCysL+ub5vnbCEtHbWhNE3qkzeo14v4wSThd60odPhxj83QXrzbveiebp0gcaEvXJg==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@ipld/dag-ucan": "^3.4.5",
+        "@noble/curves": "^1.2.0",
+        "@noble/ed25519": "^1.7.3",
+        "@noble/hashes": "^1.3.2",
+        "@ucanto/interface": "^11.0.1",
+        "multiformats": "^13.3.1",
+        "one-webcrypto": "^1.0.3"
+      }
+    },
+    "node_modules/@ucanto/server": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@ucanto/server/-/server-11.0.3.tgz",
+      "integrity": "sha512-NiiUHYnyM4UPSWKquHbi1n3a5paAl8fQ0K8ankfaME1p18JyTGcbC8SOEUOecewqBpET5jHXPe/4DDt0M9Hi9A==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@ucanto/core": "^10.4.5",
+        "@ucanto/interface": "^11.0.1",
+        "@ucanto/principal": "^9.0.3",
+        "@ucanto/validator": "^10.0.1"
+      }
+    },
+    "node_modules/@ucanto/transport": {
+      "version": "9.2.1",
+      "resolved": "https://registry.npmjs.org/@ucanto/transport/-/transport-9.2.1.tgz",
+      "integrity": "sha512-/Dhr+2vjpGO5GTKsSl8XcPQFtFdZvIA9Yk/yzzY9DHFsdI+tXrUjLWYwXcidx8EIdx5Xd9oitF4wodIZuiW8GQ==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@ucanto/core": "^10.4.5",
+        "@ucanto/interface": "^11.0.1"
+      }
+    },
+    "node_modules/@ucanto/validator": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@ucanto/validator/-/validator-10.0.1.tgz",
+      "integrity": "sha512-J1/2NAfvs55CxDEuHKMTjoLgoVrFqBbZqErYwL7TDx8Pu2V9sv7rc2wZS5dRxcM1VCEzHXY3SWeLOJuH8VgKrw==",
+      "license": "(Apache-2.0 AND MIT)",
+      "dependencies": {
+        "@ipld/car": "^5.4.0",
+        "@ipld/dag-cbor": "^9.2.2",
+        "@ucanto/core": "^10.4.5",
+        "@ucanto/interface": "^11.0.1",
+        "multiformats": "^13.3.1"
+      }
+    },
+    "node_modules/cborg": {
+      "version": "5.1.7",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-5.1.7.tgz",
+      "integrity": "sha512-rGg2MG9zZEUKtKqjkBppIWUecTXf9N1vs1Qru43vJWoDaODhCrtmzdehCaA/aq/c1cPI5A0kPrJ5Tf+jIfhV4w==",
+      "license": "Apache-2.0",
+      "bin": {
+        "cborg": "lib/bin.js"
+      }
+    },
+    "node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/one-webcrypto": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/one-webcrypto/-/one-webcrypto-1.0.3.tgz",
+      "integrity": "sha512-fu9ywBVBPx0gS9K0etIROTiCkvI5S1TDjFsYFb3rC1ewFxeOqsbzq7aIMBHsYfrTHBcGXJaONXXjTl8B01cW1Q==",
+      "license": "MIT"
+    },
+    "node_modules/varint": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/varint/-/varint-6.0.0.tgz",
+      "integrity": "sha512-cXEIW6cfr15lFv563k4GuVuW/fiwjknytD37jIOLSdSWuOI6WnO/oKwmP2FQTU2l01LP8/M5TSAJpzUaGe3uWg==",
+      "license": "MIT"
+    }
+  }
+}

--- a/caps/package.json
+++ b/caps/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@dstack-webhost/caps",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --experimental-wasm-modules test.mjs",
+    "accept": "node --experimental-wasm-modules accept.mjs",
+    "accept:remote": "node --experimental-wasm-modules accept.mjs --url"
+  },
+  "dependencies": {
+    "@biscuit-auth/biscuit-wasm": "0.6.0",
+    "@ucanto/client": "^9.0.2",
+    "@ucanto/core": "^10.4.6",
+    "@ucanto/principal": "^9.0.3",
+    "@ucanto/server": "^11.0.3",
+    "@ucanto/transport": "^9.2.1",
+    "@ucanto/validator": "^10.0.1"
+  }
+}

--- a/caps/test.mjs
+++ b/caps/test.mjs
@@ -1,0 +1,275 @@
+import { Biscuit, KeyPair, block } from "@biscuit-auth/biscuit-wasm";
+import { Delegation, delegate as ucanDelegate, invoke } from "@ucanto/core";
+import { ed25519 } from "@ucanto/principal";
+import assert from "node:assert/strict";
+import http from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createCaps, CapsAuthorizationError } from "./index.mjs";
+
+const root = new KeyPair();
+const dataDir = await mkdtemp(join(tmpdir(), "caps-test-"));
+const rootKey = root.getPrivateKey().toString();
+const caps = createCaps({ dataDir, rootKey });
+const minted = [];
+const revokedIds = new Set();
+
+try {
+  await run();
+} finally {
+  await rm(dataDir, { recursive: true, force: true });
+}
+
+async function run() {
+  await roundtrip();
+  await linkClaimRead();
+  await attenuationRefusal();
+  await scopeRefusal();
+  await sectionScoping();
+  await ucanWrongKeyRefusal();
+  await ucanScopeRefusal();
+  await expiryRefusal();
+  await ucanExpiryRefusal();
+  const revoked = await revocation();
+  const revokedUcan = await ucanRevocation();
+  await inventory();
+  await persistence(revoked, revokedUcan);
+}
+
+async function roundtrip() {
+  const { token } = mint({ path: "repo/", ops: ["read", "write"], expiry: future() });
+  await caps.write(token, "repo/A/x", Buffer.from("roundtrip"));
+  assert.equal((await caps.read(token, "repo/A/x")).toString(), "roundtrip");
+}
+
+async function linkClaimRead() {
+  const { token } = mint({ path: "repo/A/", ops: ["read"], expiry: future() });
+  assert.deepEqual(caps.verify(token, { path: "repo/A/x", op: "read" }), { ok: true });
+  assert.equal((await caps.read(token, "repo/A/x")).toString(), "roundtrip");
+}
+
+async function attenuationRefusal() {
+  const { token } = mint({ path: "repo/A/", ops: ["read"], expiry: future() });
+  const refused = caps.verify(token, { path: "repo/A/x", op: "write" });
+  assert.equal(refused.ok, false);
+  await assert.rejects(() => caps.write(token, "repo/A/x", Buffer.from("denied")), CapsAuthorizationError);
+
+  const server = http.createServer(async (req, res) => {
+    if (req.method !== "POST" || req.url !== "/write") {
+      res.writeHead(404);
+      res.end("not found");
+      return;
+    }
+    try {
+      await caps.write(token, "repo/A/x", Buffer.from("denied"));
+      res.writeHead(204);
+      res.end();
+    } catch (e) {
+      if (e instanceof CapsAuthorizationError) {
+        res.writeHead(403);
+        res.end("write refused");
+        return;
+      }
+      throw e;
+    }
+  });
+  await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
+  try {
+    const { port } = server.address();
+    const res = await fetch(`http://127.0.0.1:${port}/write`, { method: "POST" });
+    assert.equal(res.status, 403);
+  } finally {
+    await new Promise(resolve => server.close(resolve));
+  }
+}
+
+async function scopeRefusal() {
+  const { token } = mint({ path: "repo/A/", ops: ["read"], expiry: future() });
+  const refused = caps.verify(token, { path: "repo/B/y", op: "read" });
+  assert.equal(refused.ok, false);
+  await assert.rejects(() => caps.read(token, "repo/B/y"), CapsAuthorizationError);
+}
+
+async function sectionScoping() {
+  const owner = mint({ path: "repo/", ops: ["read", "write"], expiry: future() }).token;
+  await caps.write(owner, "repo/F/s2-security/body", Buffer.from("section 2"));
+  await caps.write(owner, "repo/F/_full", Buffer.from("full file"));
+
+  const { token } = mint({ path: "repo/F/s2-security/", ops: ["read"], expiry: future() });
+  assert.equal((await caps.read(token, "repo/F/s2-security/body")).toString(), "section 2");
+  assert.equal(caps.verify(token, { path: "repo/F/_full", op: "read" }).ok, false);
+  await assert.rejects(() => caps.read(token, "repo/F/_full"), CapsAuthorizationError);
+}
+
+async function expiryRefusal() {
+  const { token } = mint({ path: "repo/", ops: ["read"], expiry: past() });
+  assert.equal(caps.verify(token, { path: "repo/A/x", op: "read" }).ok, false);
+  await assert.rejects(() => caps.read(token, "repo/A/x"), CapsAuthorizationError);
+}
+
+async function ucanWrongKeyRefusal() {
+  const alice = await ed25519.generate();
+  const mallory = await ed25519.generate();
+  const { delegation } = await delegate({ toDID: alice.did(), path: "repo/A/", ops: ["read"], expiry: future() });
+
+  const refused = await caps.verify(await invocation({ delegation, signer: mallory, path: "repo/A/x", op: "read" }), {
+    path: "repo/A/x",
+    op: "read",
+  });
+  assert.equal(refused.ok, false);
+}
+
+async function ucanScopeRefusal() {
+  const alice = await ed25519.generate();
+  const bob = await ed25519.generate();
+  const { proof } = await delegate({ toDID: alice.did(), path: "repo/A/", ops: ["read"], expiry: future() });
+  const serviceDid = proof.capabilities[0].with;
+  const toBob = await ucanDelegate({
+    issuer: alice,
+    audience: bob,
+    proofs: [proof],
+    capabilities: [{ can: "file/read", with: serviceDid, nb: { path: "repo/A/x" } }],
+    expiration: seconds(future()),
+  });
+
+  const ok = await invocation({ proof: toBob, signer: bob, path: "repo/A/x", op: "read" });
+  assert.deepEqual(await caps.verify(ok, { path: "repo/A/x", op: "read" }), { ok: true });
+  assert.equal((await caps.read(ok, "repo/A/x")).toString(), "roundtrip");
+
+  const refused = await invocation({ proof: toBob, signer: bob, path: "repo/B/y", op: "read" });
+  assert.equal((await caps.verify(refused, { path: "repo/B/y", op: "read" })).ok, false);
+  await assert.rejects(() => caps.read(refused, "repo/B/y"), CapsAuthorizationError);
+}
+
+async function ucanExpiryRefusal() {
+  const alice = await ed25519.generate();
+  const { delegation } = await delegate({ toDID: alice.did(), path: "repo/A/", ops: ["read"], expiry: past() });
+  const refused = await caps.verify(await invocation({ delegation, signer: alice, path: "repo/A/x", op: "read" }), {
+    path: "repo/A/x",
+    op: "read",
+  });
+  assert.equal(refused.ok, false);
+}
+
+async function revocation() {
+  const { token, id } = mint({ path: "repo/A/", ops: ["read"], expiry: future() });
+  const descendant = Biscuit.fromBase64(token, root.getPublicKey())
+    .appendBlock(block`check if resource($p), $p.starts_with("repo/A/x");`)
+    .toBase64();
+
+  assert.deepEqual(caps.verify(token, { path: "repo/A/x", op: "read" }), { ok: true });
+  assert.deepEqual(caps.verify(descendant, { path: "repo/A/x", op: "read" }), { ok: true });
+
+  caps.revoke(id);
+  revokedIds.add(id);
+
+  assert.deepEqual(caps.verify(token, { path: "repo/A/x", op: "read" }), { ok: false, code: "REVOKED" });
+  assert.deepEqual(caps.verify(descendant, { path: "repo/A/x", op: "read" }), { ok: false, code: "REVOKED" });
+  await assert.rejects(() => caps.read(token, "repo/A/x"), CapsAuthorizationError);
+  await assert.rejects(() => caps.read(descendant, "repo/A/x"), CapsAuthorizationError);
+
+  return { id, token, descendant };
+}
+
+async function ucanRevocation() {
+  const alice = await ed25519.generate();
+  const bob = await ed25519.generate();
+  const { id, proof } = await delegate({ toDID: alice.did(), path: "repo/A/", ops: ["read"], expiry: future() });
+  const serviceDid = proof.capabilities[0].with;
+  const toBob = await ucanDelegate({
+    issuer: alice,
+    audience: bob,
+    proofs: [proof],
+    capabilities: [{ can: "file/read", with: serviceDid, nb: { path: "repo/A/x" } }],
+    expiration: seconds(future()),
+  });
+  const direct = await invocation({ proof, signer: alice, path: "repo/A/x", op: "read" });
+  const descendant = await invocation({ proof: toBob, signer: bob, path: "repo/A/x", op: "read" });
+
+  assert.deepEqual(await caps.verify(direct, { path: "repo/A/x", op: "read" }), { ok: true });
+  assert.deepEqual(await caps.verify(descendant, { path: "repo/A/x", op: "read" }), { ok: true });
+
+  caps.revoke(id);
+  revokedIds.add(id);
+
+  assert.equal((await caps.verify(direct, { path: "repo/A/x", op: "read" })).ok, false);
+  assert.equal((await caps.verify(descendant, { path: "repo/A/x", op: "read" })).ok, false);
+  await assert.rejects(() => caps.read(direct, "repo/A/x"), CapsAuthorizationError);
+  await assert.rejects(() => caps.read(descendant, "repo/A/x"), CapsAuthorizationError);
+
+  return { id, direct, descendant };
+}
+
+
+async function inventory() {
+  const grants = caps.grants();
+  assert.equal(grants.length, minted.length);
+  for (const issued of minted) {
+    const grant = grants.find(g => g.id === issued.id);
+    assert.ok(grant, `missing grant ${issued.id}`);
+    assert.equal(grant.path, issued.path);
+    assert.deepEqual(grant.ops, issued.ops);
+    assert.equal(grant.expiry, issued.expiry);
+    assert.equal(grant.revoked, revokedIds.has(grant.id));
+  }
+}
+
+async function persistence({ id, token, descendant }, ucan) {
+  const reopened = createCaps({ dataDir, rootKey });
+  assert.deepEqual(reopened.verify(token, { path: "repo/A/x", op: "read" }), { ok: false, code: "REVOKED" });
+  assert.deepEqual(reopened.verify(descendant, { path: "repo/A/x", op: "read" }), { ok: false, code: "REVOKED" });
+  assert.equal((await reopened.verify(ucan.direct, { path: "repo/A/x", op: "read" })).ok, false);
+  assert.equal((await reopened.verify(ucan.descendant, { path: "repo/A/x", op: "read" })).ok, false);
+  const persisted = reopened.grants();
+  assert.equal(persisted.length, minted.length);
+  assert.equal(persisted.find(g => g.id === id)?.revoked, true);
+  assert.equal(persisted.find(g => g.id === ucan.id)?.revoked, true);
+}
+
+function mint(args) {
+  const issued = caps.mint(args);
+  minted.push({
+    id: issued.id,
+    path: args.path,
+    ops: [...new Set(args.ops)],
+    expiry: new Date(args.expiry).toISOString(),
+  });
+  return issued;
+}
+
+async function delegate(args) {
+  const issued = await caps.delegate(args);
+  const extracted = await Delegation.extract(issued.delegation);
+  assert.ok(extracted.ok, extracted.error?.message);
+  minted.push({
+    id: issued.id,
+    path: args.path,
+    ops: [...new Set(args.ops)],
+    expiry: new Date(args.expiry).toISOString(),
+  });
+  return { ...issued, proof: extracted.ok };
+}
+
+async function invocation({ delegation, proof, signer, path, op }) {
+  const extracted = proof ?? (await Delegation.extract(delegation)).ok;
+  assert.ok(extracted);
+  return invoke({
+    issuer: signer,
+    audience: { did: () => extracted.capabilities[0].with },
+    proofs: [extracted],
+    capability: { can: `file/${op}`, with: extracted.capabilities[0].with, nb: { path } },
+  });
+}
+
+function seconds(date) {
+  return Math.floor(date.getTime() / 1000);
+}
+
+function future() {
+  return new Date(Date.now() + 3600_000);
+}
+
+function past() {
+  return new Date(Date.now() - 3600_000);
+}

--- a/kanban.json
+++ b/kanban.json
@@ -1,1 +1,229 @@
-{"tasks":[{"id":"0001-1","title":"Network separation","rfc":"0001-platform-vision","description":"Create tee-apps-dev and tee-apps-attested networks, enforce isolation in the Docker proxy","status":"done"},{"id":"0001-2","title":"Mode field on projects","rfc":"0001-platform-vision","description":"Add mode: dev|attested to the project manifest, default to dev on deploy","status":"done"},{"id":"0001-3","title":"Promotion API","rfc":"0001-platform-vision","description":"POST /_api/projects/<name>/promote with source hash recording","status":"done"},{"id":"0001-4","title":"Audit log","rfc":"0001-platform-vision","description":"Make it per-project, enable only for attested mode","status":"done"},{"id":"0001-5","title":"Verification page","rfc":"0001-platform-vision","description":"Static endpoint that walks the trust chain","status":"done"},{"id":"0001-6","title":"Agent skill","rfc":"0001-platform-vision","description":"Verification skill that can be pointed at any dstack-webhost instance","status":"done"},{"id":"0001-7","title":"Developer guide","rfc":"0001-platform-vision","description":"Step-by-step from local TypeScript to attested production","status":"done"},{"id":"0002-1","title":"Port binding in project manifest","rfc":"0002-multi-routing","description":"Add listen.port and listen.protocol fields to project config, default to 8080/http","status":"done"},{"id":"0002-2","title":"Port-based routing","rfc":"0002-multi-routing","description":"When a project specifies a port, bind that port and route all traffic directly to the container (no path-based routing)","status":"done"},{"id":"0002-3","title":"TCP proxy mode","rfc":"0002-multi-routing","description":"Add raw TCP stream proxy for non-HTTP services, bidirectional byte forwarding","status":"done"},{"id":"0002-4","title":"Routing table endpoint","rfc":"0002-multi-routing","description":"GET /_api/routes returns the current routing table with port, protocol, project mapping","status":"done"},{"id":"0002-5","title":"Port conflict detection","rfc":"0002-multi-routing","description":"Prevent two projects from binding the same port, return clear error on deploy","status":"done"},{"id":"0003-1","title":"Tunnel API","rfc":"0003-temporary-proxy-access","description":"POST /_api/tunnels creates a temporary reverse proxy entry with timeout and optional auth","status":"done"},{"id":"0003-2","title":"Tunnel proxy handler","rfc":"0003-temporary-proxy-access","description":"Route requests matching /<tunnel-id>/... to the backend URL, remove route after timeout","status":"done"},{"id":"0003-3","title":"WebSocket relay","rfc":"0003-temporary-proxy-access","description":"Support WS upgrade on tunnel endpoints for interactive sessions","status":"done"},{"id":"0003-4","title":"Tunnel lifecycle management","rfc":"0003-temporary-proxy-access","description":"Auto-cleanup of expired tunnels, GET /_api/tunnels to list active, DELETE /_api/tunnels/<id> to revoke","status":"done"},{"id":"0004-1","title":"Add X-Forwarded-For and proxy headers to ingress","rfc":"0004-ingress-proxy-headers","description":"Add X-Forwarded-For, X-Real-IP, X-Forwarded-Proto headers in proxy/ingress.py _proxy() before forwarding. Handle chained proxies by appending.","status":"done"},{"id":"0005-1","title":"Rewrite ingress for streaming and WebSocket support","rfc":"0005-streaming-websocket-ingress","description":"Replace buffered request/response in _proxy() with StreamResponse. Handle Connection: Upgrade for WebSocket. Support SSE, chunked transfer, large uploads. Most impactful change.","status":"done"},{"id":"0006-1","title":"Add structured request logging to ingress","rfc":"0006-request-logging","description":"Log every proxied request with method, path, status, duration_ms, client_ip, upstream target. JSON format. INFO for success, WARNING for 4xx, ERROR for 5xx.","status":"done"},{"id":"0007-1","title":"Implement Deno runtime hot-reload on file change","rfc":"0007-deno-hot-reload","description":"Add Deno.watchFs() on projects dir to detect new/changed files and re-import modules without container restart. Debounce 500ms. Keep old module on import failure.","status":"done"},{"id":"0008-1","title":"Standardize multipart deploy API format","rfc":"0008-consistent-deploy-api","description":"Reconcile running daemon vs repo code. Make multipart/form-data canonical with manifest + files fields. Add backward compat for JSON body. Validate and return clear errors.","status":"done"},{"id":"0009-1","title":"Add health check endpoint and post-deploy verification","rfc":"0009-runtime-health-checks","description":"Add /_health endpoint to Deno router. Poll after deploy with exponential backoff (30s timeout). Return error with container logs if unhealthy.","status":"done"},{"id":"0010-1","title":"Fix refresh() to restart runtime when projects remain","rfc":"0010-reliable-runtime-restart","description":"refresh() should restart container even when remaining projects exist, so redeployed code gets picked up. Add grace period for draining in-flight requests.","status":"done"},{"id":"0011-1","title":"Add git to Deno runtime container image","rfc":"0011-git-in-deno-runtime","description":"Add git to Deno Dockerfile. Add error checking on git clone exit code. Validate cloned dir is non-empty.","status":"done"},{"id":"0012-1","title":"Switch tunnel relay from polling to WebSocket","rfc":"0012-tunnel-latency","description":"Replace poll/relay with persistent WebSocket between tunnel client and server. Add reconnection and heartbeat. Keep polling as fallback. Depends on RFC 0005.","status":"done"},{"id":"0013-1","title":"Move tunnel auth from URL to headers","rfc":"0013-tunnel-header-auth","description":"Accept Authorization: Bearer header as alternative to URL path auth. Deprecate URL-based auth with warning log.","status":"done"},{"id":"0014-1","title":"Pass project dir as env var instead of import.meta.url","rfc":"0014-volume-mount-env-var","description":"Set __PROJECT_DIR env var when router imports handler modules. Update docs to prefer env var over import.meta.url. Keep backward compat.","status":"done"}],"summary":"Extracted 27 tasks from 14 RFCs: 0001 (7 tasks), 0002 (5 tasks), 0003 (4 tasks), 0004-0014 (1 task each). 22 tasks completed, 5 in backlog."}
+{
+  "tasks": [
+    {
+      "id": "0001-1",
+      "title": "Network separation",
+      "rfc": "0001-platform-vision",
+      "description": "Create tee-apps-dev and tee-apps-attested networks, enforce isolation in the Docker proxy",
+      "status": "done"
+    },
+    {
+      "id": "0001-2",
+      "title": "Mode field on projects",
+      "rfc": "0001-platform-vision",
+      "description": "Add mode: dev|attested to the project manifest, default to dev on deploy",
+      "status": "done"
+    },
+    {
+      "id": "0001-3",
+      "title": "Promotion API",
+      "rfc": "0001-platform-vision",
+      "description": "POST /_api/projects/<name>/promote with source hash recording",
+      "status": "done"
+    },
+    {
+      "id": "0001-4",
+      "title": "Audit log",
+      "rfc": "0001-platform-vision",
+      "description": "Make it per-project, enable only for attested mode",
+      "status": "done"
+    },
+    {
+      "id": "0001-5",
+      "title": "Verification page",
+      "rfc": "0001-platform-vision",
+      "description": "Static endpoint that walks the trust chain",
+      "status": "done"
+    },
+    {
+      "id": "0001-6",
+      "title": "Agent skill",
+      "rfc": "0001-platform-vision",
+      "description": "Verification skill that can be pointed at any dstack-webhost instance",
+      "status": "done"
+    },
+    {
+      "id": "0001-7",
+      "title": "Developer guide",
+      "rfc": "0001-platform-vision",
+      "description": "Step-by-step from local TypeScript to attested production",
+      "status": "done"
+    },
+    {
+      "id": "0002-1",
+      "title": "Port binding in project manifest",
+      "rfc": "0002-multi-routing",
+      "description": "Add listen.port and listen.protocol fields to project config, default to 8080/http",
+      "status": "done"
+    },
+    {
+      "id": "0002-2",
+      "title": "Port-based routing",
+      "rfc": "0002-multi-routing",
+      "description": "When a project specifies a port, bind that port and route all traffic directly to the container (no path-based routing)",
+      "status": "done"
+    },
+    {
+      "id": "0002-3",
+      "title": "TCP proxy mode",
+      "rfc": "0002-multi-routing",
+      "description": "Add raw TCP stream proxy for non-HTTP services, bidirectional byte forwarding",
+      "status": "done"
+    },
+    {
+      "id": "0002-4",
+      "title": "Routing table endpoint",
+      "rfc": "0002-multi-routing",
+      "description": "GET /_api/routes returns the current routing table with port, protocol, project mapping",
+      "status": "done"
+    },
+    {
+      "id": "0002-5",
+      "title": "Port conflict detection",
+      "rfc": "0002-multi-routing",
+      "description": "Prevent two projects from binding the same port, return clear error on deploy",
+      "status": "done"
+    },
+    {
+      "id": "0003-1",
+      "title": "Tunnel API",
+      "rfc": "0003-temporary-proxy-access",
+      "description": "POST /_api/tunnels creates a temporary reverse proxy entry with timeout and optional auth",
+      "status": "done"
+    },
+    {
+      "id": "0003-2",
+      "title": "Tunnel proxy handler",
+      "rfc": "0003-temporary-proxy-access",
+      "description": "Route requests matching /<tunnel-id>/... to the backend URL, remove route after timeout",
+      "status": "done"
+    },
+    {
+      "id": "0003-3",
+      "title": "WebSocket relay",
+      "rfc": "0003-temporary-proxy-access",
+      "description": "Support WS upgrade on tunnel endpoints for interactive sessions",
+      "status": "done"
+    },
+    {
+      "id": "0003-4",
+      "title": "Tunnel lifecycle management",
+      "rfc": "0003-temporary-proxy-access",
+      "description": "Auto-cleanup of expired tunnels, GET /_api/tunnels to list active, DELETE /_api/tunnels/<id> to revoke",
+      "status": "done"
+    },
+    {
+      "id": "0004-1",
+      "title": "Add X-Forwarded-For and proxy headers to ingress",
+      "rfc": "0004-ingress-proxy-headers",
+      "description": "Add X-Forwarded-For, X-Real-IP, X-Forwarded-Proto headers in proxy/ingress.py _proxy() before forwarding. Handle chained proxies by appending.",
+      "status": "done"
+    },
+    {
+      "id": "0005-1",
+      "title": "Rewrite ingress for streaming and WebSocket support",
+      "rfc": "0005-streaming-websocket-ingress",
+      "description": "Replace buffered request/response in _proxy() with StreamResponse. Handle Connection: Upgrade for WebSocket. Support SSE, chunked transfer, large uploads. Most impactful change.",
+      "status": "done"
+    },
+    {
+      "id": "0006-1",
+      "title": "Add structured request logging to ingress",
+      "rfc": "0006-request-logging",
+      "description": "Log every proxied request with method, path, status, duration_ms, client_ip, upstream target. JSON format. INFO for success, WARNING for 4xx, ERROR for 5xx.",
+      "status": "done"
+    },
+    {
+      "id": "0007-1",
+      "title": "Implement Deno runtime hot-reload on file change",
+      "rfc": "0007-deno-hot-reload",
+      "description": "Add Deno.watchFs() on projects dir to detect new/changed files and re-import modules without container restart. Debounce 500ms. Keep old module on import failure.",
+      "status": "done"
+    },
+    {
+      "id": "0008-1",
+      "title": "Standardize multipart deploy API format",
+      "rfc": "0008-consistent-deploy-api",
+      "description": "Reconcile running daemon vs repo code. Make multipart/form-data canonical with manifest + files fields. Add backward compat for JSON body. Validate and return clear errors.",
+      "status": "done"
+    },
+    {
+      "id": "0009-1",
+      "title": "Add health check endpoint and post-deploy verification",
+      "rfc": "0009-runtime-health-checks",
+      "description": "Add /_health endpoint to Deno router. Poll after deploy with exponential backoff (30s timeout). Return error with container logs if unhealthy.",
+      "status": "done"
+    },
+    {
+      "id": "0010-1",
+      "title": "Fix refresh() to restart runtime when projects remain",
+      "rfc": "0010-reliable-runtime-restart",
+      "description": "refresh() should restart container even when remaining projects exist, so redeployed code gets picked up. Add grace period for draining in-flight requests.",
+      "status": "done"
+    },
+    {
+      "id": "0011-1",
+      "title": "Add git to Deno runtime container image",
+      "rfc": "0011-git-in-deno-runtime",
+      "description": "Add git to Deno Dockerfile. Add error checking on git clone exit code. Validate cloned dir is non-empty.",
+      "status": "done"
+    },
+    {
+      "id": "0012-1",
+      "title": "Switch tunnel relay from polling to WebSocket",
+      "rfc": "0012-tunnel-latency",
+      "description": "Replace poll/relay with persistent WebSocket between tunnel client and server. Add reconnection and heartbeat. Keep polling as fallback. Depends on RFC 0005.",
+      "status": "done"
+    },
+    {
+      "id": "0013-1",
+      "title": "Move tunnel auth from URL to headers",
+      "rfc": "0013-tunnel-header-auth",
+      "description": "Accept Authorization: Bearer header as alternative to URL path auth. Deprecate URL-based auth with warning log.",
+      "status": "done"
+    },
+    {
+      "id": "0014-1",
+      "title": "Pass project dir as env var instead of import.meta.url",
+      "rfc": "0014-volume-mount-env-var",
+      "description": "Set __PROJECT_DIR env var when router imports handler modules. Update docs to prefer env var over import.meta.url. Keep backward compat.",
+      "status": "done"
+    },
+    {
+      "id": "0032-1",
+      "title": "caps module: Biscuit verifier + file store",
+      "rfc": "0032-capability-storage-module",
+      "description": "Library form: volume-backed file tree, Biscuit mint/verify (path-prefix + ops + expiry caveats), claim links. Port from storage-bakeoff/caps-server (root key from dstack KMS in attested mode, not Static env).",
+      "status": "done"
+    },
+    {
+      "id": "0032-2",
+      "title": "caps module: revocation denylist + issuance log",
+      "rfc": "0032-capability-storage-module",
+      "description": "sqlite: revoked Biscuit block-ids (subtree revoke) + issuance log for grant inventory; revoke button on owner UI.",
+      "status": "done"
+    },
+    {
+      "id": "0032-3",
+      "title": "caps module: ucanto identity-bound verifier",
+      "rfc": "0032-capability-storage-module",
+      "description": "Second credential type: UCAN delegation chains to a DID, signed invocations, revocation via validateAuthorization CID denylist. Port from landscape/ucanto exp1-5.",
+      "status": "done"
+    },
+    {
+      "id": "0032-4",
+      "title": "caps module: acceptance test on staging",
+      "rfc": "0032-capability-storage-module",
+      "description": "Bake-off scenario as CI-able script vs a staging pod: roundtrip, link claim, attenuation refusal, stranger refusal, section scoping, revocation kills link, inventory enumerates grants.",
+      "status": "done"
+    },
+    {
+      "id": "0032-5",
+      "title": "TEE co-signer extension (rung 3)",
+      "rfc": "0032-capability-storage-module",
+      "description": "Attested approver pod signing resource-bound Biscuit third-party blocks per use; composes with RFC 0024 mutual attestation. Extension \u2014 after 0031-1..4.",
+      "status": "todo"
+    }
+  ],
+  "summary": "Extracted 27 tasks from 14 RFCs: 0001 (7 tasks), 0002 (5 tasks), 0003 (4 tasks), 0004-0014 (1 task each). 22 tasks completed, 5 in backlog."
+}

--- a/rfcs/0032-capability-storage-module.md
+++ b/rfcs/0032-capability-storage-module.md
@@ -1,0 +1,116 @@
+# RFC 0032: Capability storage module for webhost apps
+
+**Status**: Ready for implementation (kanban 0032-1..5; start at 0031-1)
+
+## Summary
+
+Give webhost apps a standard **capability-storage module**: path-scoped, link-issuable
+read/write capabilities over pod-owned files, built on permissive primitives instead of
+tinycloud-node's EGPL stack. Two token types cover the useful rungs of the identity
+ladder — **Biscuit** (Apache-2.0) for bearer links with offline holder attenuation, and
+**ucanto** (Apache/MIT) for identity-bound standing delegations — behind one file store
+and one authorization surface. An extension point adds per-use **TEE co-signing** for
+sensitive operations via Biscuit third-party blocks.
+
+Grounded in the 2026-07-10 bake-off: both arms are already live
+(`/capdemo` tinycloud-backed, `/caps-server` Biscuit at 173 lines), seven systems were
+evaluated hands-on (`~/projects/storage-bakeoff/landscape/`), and the full report is at
+`pod.dstack.soc1024.com/bakeoff-report/`.
+
+## Problem
+
+- Pods have no data-sharing primitive. Every app that wants "give this person a link to
+  read this file" rolls its own auth or reaches for a platform (tinycloud-node), whose
+  EGPL gates production use and non-"aligned" deployment.
+- The bake-off showed the delegation semantics are cheap to own: path/file/section-scoped
+  read-write links in ~173 Apache-licensed lines; identity-bound UCAN chains with a
+  revocation hook in one pure-JS container. ~85% of tinycloud's auth core is still-Apache
+  Kepler code; the features we need predate the relicense.
+- What no single permissive primitive provides is the *server around the token*: storage,
+  issuance/claim UX, revocation state, grant inventory, and multi-tenant identity. That's
+  the module this RFC specifies, so apps get it once instead of ad hoc.
+
+## Design
+
+1. **One file store, two verifiers.** An app-local module (library first; optionally a
+   shared `caps` service app later) owning a volume-backed file tree, authorizing each request by
+   whichever credential arrives:
+   - **Biscuit token** (rung 1 — bearer link): path-prefix + operation + expiry caveats,
+     ~470 B, offline-verifiable against the module's root public key. Recipients can
+     attenuate offline (folder-rw → file-ro) with no server round-trip; re-widening is
+     cryptographically blocked.
+   - **ucanto invocation** (rung 2 — identity-bound): UCAN delegation chains to a DID;
+     invocations are signed, so wrong-key replay fails and over-delegation is caught at
+     every hop. For agents and SDK-style integrations holding standing access.
+2. **Links.** `claim/<id>` URLs as in the live demos. Biscuit links carry the token
+   (bearer). ucanto links embed a throwaway keypair + delegation (22-line pattern) when
+   zero-onboarding is wanted; standing grants delegate to the recipient's existing DID.
+3. **Revocation + inventory.** sqlite table of revoked Biscuit block-ids (revoking a root
+   block kills its whole attenuation subtree) and revoked ucanto delegation CIDs (checked
+   in `validateAuthorization`). All issuance is logged, giving the operator the rung-4
+   property token systems lack: enumerate outstanding grants.
+4. **Rung-3 extension: TEE co-signer.** Sensitive operations mint tokens carrying
+   `check if approved($p) trusting <TEE pubkey>`; an attested approver app signs a
+   resource-bound approval per use (verified fail-closed in the bake-off). This is the
+   OAuth3 thesis in capability form and composes with RFC 0024 mutual attestation and
+   RFC 0025's caps⟹attested rule.
+5. **Identity/recovery rule.** Durable authority lives with a *recoverable* root — the
+   operator's dstack-KMS-derived key or an email-attested account — which mints and
+   revokes disposable agent/device keys. Never bake a raw user key into a namespace
+   (tinycloud's space-name-is-the-key design has no rotation story; Storacha's
+   `did:mailto` root is the model to follow).
+
+## Non-goals
+
+- The whole-platform SDK surface (VFS, SQL, hooks, client encryption) — apps that want
+  that breadth should weigh tinycloud's EGPL terms deliberately.
+- E2EE at rest (capability = decryption key). That's Peergos' model; if it becomes a
+  requirement, evaluate promoting the Peergos arm instead of bolting crypto onto this.
+- tinycloud wire-protocol interop.
+
+## Alternatives considered
+
+- **tinycloud-node as the module**: right shape, proven on prod, but EGPL production
+  gating, no revocation, protocol-version lockstep, and the unrecoverable-root identity
+  flaw. Remains viable if the licensing ask (Additional Use Grant / MIT on node+SDK) lands.
+- **OpenFGA**: instant revocation + grant inventory in one sqlite container, but
+  server-resident only — loses offline links and attenuation. Could later back the
+  inventory/audit side of this module.
+- **Kepler fork**: Apache ancestor builds and boots; 3–5 days to a modernized fork.
+  Kept as the negotiation BATNA rather than the build path.
+
+## Library API contract (0031-1/2/3 build to this)
+
+```ts
+createCaps({ dataDir, rootKey, db }): Caps        // rootKey: biscuit "ed25519-private/…" serialization
+caps.mint({ path, ops, expiry }): { token, id }   // ops ⊆ ["read","write"]; path is a prefix
+caps.verify(credential, { path, op }): { ok } | { ok:false, code }   // credential = Biscuit token (0031-1) or ucanto invocation (0031-3)
+caps.read(credential, path) / caps.write(credential, path, bytes)    // verify + file I/O
+caps.revoke(id): void                             // 0031-2: kills token AND its attenuated descendants
+caps.grants(): Grant[]                            // 0031-2: issuance log incl. revoked flag
+```
+
+Reference implementations to port (do not redesign): `storage-bakeoff/caps-server/server.mjs`
+(Biscuit mint/verify — `authorizeWithLimits` is REQUIRED or first calls time out, and run
+node with `--experimental-wasm-modules`; bun cannot load the wasm) and
+`storage-bakeoff/landscape/ucanto/{lib,exp1-2,exp3-link,exp4-revocation}.mjs`
+(identity-bound arm; pure JS).
+
+## Acceptance (E2E, scriptable; each numbered item is a hard pass/fail)
+
+Run against the library exercised through a demo HTTP server (the caps-server UI is fine):
+
+1. roundtrip: `mint({path:"repo/", ops:[read,write]})` → write → read → bytes equal.
+2. link-claim read: a read-only token for `repo/A/` reads `repo/A/x` — via the token alone.
+3. attenuation refusal: that token's write to `repo/A/x` → `{ok:false}` AND HTTP 403.
+4. scope refusal: read of `repo/B/y` with the `repo/A/` token → refused.
+5. section scoping: token scoped to `repo/F/s2-…/` reads that section, cannot read `repo/F/_full`.
+6. wrong-key/stranger (0031-3): replaying a delegation with a different signing key → refused.
+7. expiry: token minted with a past expiry → refused.
+8. revocation (0031-2): after `revoke(id)`, check 2 flips ok→refused; a HOLDER-ATTENUATED
+   descendant of the revoked token is also refused.
+9. inventory (0031-2): `grants()` lists every mint from 1–8 with path/ops/expiry/revoked.
+10. persistence: restart the process; 8 and 9 still hold (sqlite-backed).
+
+0031-4 packages 1–10 as an exit-code script runnable in CI and against a staging
+deployment. Timings are informational, not gated.


### PR DESCRIPTION
## Why merge: acceptance is green against the live staging deployment

| # | criterion | local | remote (staging) |
|---|---|---|---|
| 1 | roundtrip | PASS | PASS 662ms |
| 2 | link-claim read | PASS | PASS 307ms |
| 3 | attenuation refusal (403) | PASS | PASS 301ms |
| 4 | scope refusal | PASS | PASS 293ms |
| 5 | section scoping | PASS | PASS 665ms |
| 6 | wrong-key/stranger (ucanto) | PASS | PASS 373ms |
| 7 | expiry | PASS | PASS 281ms |
| 8 | revocation (incl. attenuated descendants) | PASS | PASS 1044ms |
| 9 | inventory | PASS | PASS 140ms |
| 10 | restart persistence | PASS | SKIP (unreachable over HTTP, by design — never silently passed) |

**Live now:** [staging deployment](https://78ffc78c25e0c8a9e64bb3a969ba6f226abae62d-8080.dstack-pha-prod7.phala.network/caps-demo/healthz) (`caps-demo`, image `ghcr.io/amiller/capdemo:caps-module` @ `sha256:b41808e2…`) · [acceptance report page](https://78ffc78c25e0c8a9e64bb3a969ba6f226abae62d-8080.dstack-pha-prod7.phala.network/caps-accept-report/)
Reproduce: `cd caps && npm ci && npm run accept` (local 10/10) or `npm run accept:remote -- <url>`.

## What you get

One library (`caps/index.mjs`, 315 lines): **Biscuit bearer links** (path/file/section-scoped, offline holder-attenuable) + **ucanto identity-bound delegations** (signed invocations, wrong-key replay refused) behind a single `createCaps` API — with sqlite **revocation** (revoking a mint kills its attenuated descendants) and a **grant inventory**, the two things no token system (including tinycloud) ships. Apache-licensed end to end. Plus `demo-server.mjs`, the acceptance suite, RFC 0032, kanban 0032-1..4 done, and the AGENTS.md Definition-of-Done (review = read a report, not a diff).

## Review notes (from orchestrator code-read)

- `revoked_biscuit_ids` table also stores ucanto CIDs — rename to `revocations` sometime
- root-key sourcing from dstack KMS is deploy-layer TODO (library takes `rootKey` param; demo server self-bootstraps to its volume)
- ucanto Server allocated per-verify — cache if it ever gets hot

## Deferred (not in this PR)

0032-5 TEE co-signer extension (gated on this review) · shared caps *service app* variant · caps-demo/caps-accept-report staging apps are demo pods, retire at will.

Provenance: built by 4 chained paseo workers on zed (kanban 0032-1..4), each step independently re-verified by the orchestrator before the next was spawned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)