### PR TITLE
td-0020-2: verify TDX quotes with dcap-qvl

### DIFF
--- a/verify.md
+++ b/verify.md
@@ -12,6 +12,18 @@ You hit a TEE-hosted app. This page is the audit-ready report for what's running
 
 The mechanical part — proving the code running on this CVM is the same code in the public GitHub repo — is resolved on this page, automatically, on load. The judgmental part — whether the code does what it claims — is the source-reading work below. You don't have to do it; you can pass the URL to someone whose job it is.
 
+## Consumer verification
+
+The Python `verify()` library runs Phala's local DCAP/QVL verifier. Install its CLI before
+using the library:
+
+```sh
+cargo install dcap-qvl-cli
+```
+
+It returns structured facts, including quote validity and measurements; the consumer still
+chooses its acceptance policy.
+
 <p class="target"><span class="muted">Reading:</span> <code id="targetLine">timelock at hermes-staging</code></p>
 
 ## Provenance

--- a/verify/facts.py
+++ b/verify/facts.py
@@ -16,9 +16,9 @@ emptying out. The round-trip test (``test_bundle_roundtrip``) locks that
 contract.
 
 The library is honest about what it can and cannot verify:
-- The TDX quote is parsed but DCAP/QVL signature verification requires external
-  tooling (Intel PCS / Phala verifier, tracked separately as #93); quote_valid
-  stays False until that lands — never claim a verdict we did not earn.
+- The TDX quote is verified with the dcap-qvl CLI (signature + collateral,
+  #93); a missing tool, malformed quote, or failed verification surfaces in
+  quote.verification_error with quote_valid False — never a masked pass.
 - On non-anchored ecosystems (chain_id 0, e.g. pha-prod), onchain_approved is
   surfaced as False — a FACT, not an error. With consumer-supplied chain_config,
   the base-prod DstackApp allowlist is checked over eth_call and the result
@@ -34,8 +34,13 @@ The library is honest about what it can and cannot verify:
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
-from dataclasses import dataclass, field
+import os
+import re
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass, field
 from typing import Any, Literal
 from urllib.parse import urlparse
 
@@ -88,6 +93,8 @@ class QuoteFacts:
     collateral_url: str = ""
     verification_error: str = ""
     quote_raw: str = ""
+    report_data: str = ""
+    signature_chain_root: str = ""
 
 
 @dataclass
@@ -176,6 +183,8 @@ class Facts:
                 "rtmr": self.quote.rtmr,
                 "collateral_url": self.quote.collateral_url,
                 "verification_error": self.quote.verification_error,
+                "quote_raw": self.quote.quote_raw,
+                "report_data": self.quote.report_data,
             },
             "binding": {
                 "kind": self.binding.kind,
@@ -282,10 +291,13 @@ def _compute_report_data_preimage(
 
 def _verify_quote_signature(platform_quote: dict) -> QuoteFacts:
     """
-    Extract TDX quote fields. Full DCAP/QVL signature verification requires
-    external tooling (Intel PCS collateral / Phala verifier) and is NOT
-    performed here — quote_valid stays False and the limitation is surfaced as
-    a fact, never masked. Wiring real DCAP/QVL is tracked as #93.
+    Verify the TDX platform quote with the dcap-qvl CLI (signature and
+    collateral verification) and parse the verified report into MRTD/RTMR
+    facts (#93). A missing tool, malformed quote, or failed verification is
+    surfaced in verification_error with quote_valid False — never masked.
+
+    Args:
+        platform_quote: TDX GetQuote response from the bundle
     """
     facts = QuoteFacts()
     if not platform_quote:
@@ -296,8 +308,57 @@ def _verify_quote_signature(platform_quote: dict) -> QuoteFacts:
         facts.quote_raw = quote_blob
         facts.quote_format = "tdx-legacy"
     facts.report_data = platform_quote.get("report_data", "") or ""
-    facts.verification_error = "DCAP/QVL quote signature verification not performed"
-    facts.quote_valid = False
+    if not facts.quote_raw:
+        facts.verification_error = "Quote data has no raw TDX quote"
+        return facts
+    if not re.fullmatch(r"(?:0x)?[0-9a-fA-F\s]+", facts.quote_raw) or len(re.sub(r"^0x|\s", "", facts.quote_raw)) % 2:
+        facts.verification_error = "TDX quote is not valid hexadecimal"
+        return facts
+
+    try:
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".quote", delete=False) as quote_file:
+            quote_file.write(facts.quote_raw)
+            quote_path = quote_file.name
+        try:
+            result = subprocess.run(
+                ["dcap-qvl", "verify", "--hex", quote_path],
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        finally:
+            os.unlink(quote_path)
+    except FileNotFoundError:
+        facts.verification_error = "dcap-qvl is not installed or not on PATH"
+        return facts
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        facts.verification_error = f"dcap-qvl execution failed: {exc}"
+        return facts
+
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip().splitlines()
+        facts.verification_error = detail[-1] if detail else f"dcap-qvl exited with status {result.returncode}"
+        return facts
+
+    try:
+        report = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        facts.verification_error = f"dcap-qvl returned invalid JSON: {exc}"
+        return facts
+
+    facts.quote_valid = True
+    facts.quote_format = "tdx"
+    facts.verification_error = ""
+    report_data = report.get("report", {})
+    report_data = report_data.get("TD15", {}).get("base", report_data.get("TD10", report_data))
+    facts.mrtd = report_data.get("mr_td", "")
+    facts.rtmr = {
+        f"rtmr{i}": report_data.get(f"rt_mr{i}", "")
+        for i in range(4)
+        if report_data.get(f"rt_mr{i}")
+    }
+    facts.report_data = report_data.get("report_data", facts.report_data)
     return facts
 
 
@@ -359,6 +420,69 @@ def _extract_onchain_facts(onchain: OnchainInfo) -> OnchainFacts:
     if chain_id not in (0, 8453):
         facts.error = f"unexpected chain_id {chain_id}; no policy to evaluate"
     return facts
+
+
+def _quoted_compose_hash(quote_data: dict) -> str:
+    event_log = quote_data.get("event_log", [])
+    if isinstance(event_log, str):
+        try:
+            event_log = json.loads(event_log)
+        except json.JSONDecodeError:
+            return ""
+    if not isinstance(event_log, list):
+        return ""
+    for event in reversed(event_log):
+        if isinstance(event, dict) and event.get("event") == "compose-hash":
+            return str(event.get("event_payload", ""))
+    return ""
+
+
+def _compare_measurements(
+    quote_facts: QuoteFacts,
+    quote_data: dict,
+    approved: dict | None,
+) -> list[str]:
+    """Compare quote measurements with explicit consumer-supplied approval data."""
+    if not approved:
+        return []
+    errors = []
+    approved_compose = str(approved.get("allowed_compose_hash", approved.get("compose_hash", "")))
+    quoted_compose = _quoted_compose_hash(quote_data)
+    if approved_compose:
+        if not quoted_compose:
+            errors.append("measurement mismatch: quote has no measured compose hash")
+        elif quoted_compose != approved_compose:
+            errors.append(
+                f"measurement mismatch: quote compose hash {quoted_compose} != approved {approved_compose}"
+            )
+    approved_mrtd = str(approved.get("mrtd", ""))
+    if approved_mrtd and quote_facts.mrtd.lower() != approved_mrtd.lower():
+        errors.append(f"measurement mismatch: MRTD {quote_facts.mrtd} != approved {approved_mrtd}")
+    approved_rtmr = approved.get("rtmr", {})
+    if isinstance(approved_rtmr, dict):
+        for name, expected in approved_rtmr.items():
+            actual = quote_facts.rtmr.get(name, "")
+            if actual.lower() != str(expected).lower():
+                errors.append(f"measurement mismatch: {name} {actual} != approved {expected}")
+    return errors
+
+
+def _audit_source_errors(tree_hash: str, audit_log: list) -> list[str]:
+    if not tree_hash or not audit_log:
+        return []
+    recorded = set()
+    for entry in audit_log:
+        detail = entry.get("detail", {}) if isinstance(entry, dict) else {}
+        if isinstance(detail, str):
+            try:
+                detail = json.loads(detail)
+            except json.JSONDecodeError:
+                continue
+        if isinstance(detail, dict) and detail.get("tree_hash"):
+            recorded.add(detail["tree_hash"])
+    if recorded and tree_hash not in recorded:
+        return [f"source binding mismatch: tree hash {tree_hash} is absent from the audit log"]
+    return []
 
 
 async def _verify_onchain_approval(
@@ -556,6 +680,11 @@ async def _verify_bundle(
     facts.quote = _verify_quote_signature(bundle.platform_quote)
     if facts.quote.verification_error:
         facts.errors.append(f"quote: {facts.quote.verification_error}")
+    # measurement comparison vs consumer-supplied approval data (chain_config),
+    # else the bundle's own declared onchain allowlist — explicit, never silent
+    facts.errors.extend(_compare_measurements(
+        facts.quote, bundle.platform_quote, chain_config or asdict(bundle.onchain)
+    ))
 
     # binding leg (RFC 0025 report-data preimage)
     binding_quote = bundle.app.binding_quote
@@ -588,6 +717,7 @@ async def _verify_bundle(
     # audit sanity — a bundle with no promote event has no binding trail
     if not any(isinstance(e, dict) and e.get("action") == "promote" for e in bundle.audit):
         facts.errors.append("audit: no promote event recorded")
+    facts.errors.extend(_audit_source_errors(facts.source.tree_hash, bundle.audit))
 
     if base_url:
         facts.channel.domain = facts.channel.domain or urlparse(base_url).netloc

--- a/verify/test_facts.py
+++ b/verify/test_facts.py
@@ -9,7 +9,9 @@ verdict; accept/reject lives in the consumer (see verify/policies.py).
 
 import asyncio
 import json
+import subprocess
 from pathlib import Path
+from unittest.mock import patch
 
 import aiohttp
 import pytest
@@ -93,7 +95,8 @@ def test_two_policies_disagree_on_same_facts():
     # Policy (a): allowlist the bundle's own tree_hash -> ACCEPTS
     accepts = allowlist_policy(facts, {facts.source.tree_hash})
     # Policy (b): strict — needs quote_valid && onchain_approved && gateway &&
-    # chain_id==8453. On the staging fixture ALL of those are False/empty/0.
+    # chain_id==8453. On the staging fixture the onchain/gateway/chain_id legs
+    # are False/empty/0, so strict rejects regardless of the quote leg.
     rejects = strict_policy(facts, expected_chain_id=8453)
 
     assert accepts is True, "allowlist policy should accept its own tree_hash"
@@ -425,6 +428,44 @@ def test_onchain_rpc_failure_flows_into_facts_errors():
     assert any(e.startswith("onchain:") for e in facts.errors)
 
 
+def test_qvl_report_is_parsed_and_missing_tool_is_specific():
+    from verify.facts import _verify_quote_signature
+
+    qvl_report = json.dumps({
+        "status": "UpToDate",
+        "report": {"TD10": {
+            "mr_td": "aa" * 48,
+            "rt_mr0": "bb" * 48,
+            "rt_mr1": "cc" * 48,
+            "rt_mr2": "dd" * 48,
+            "rt_mr3": "ee" * 48,
+            "report_data": "ff" * 64,
+        }},
+    })
+    completed = subprocess.CompletedProcess(
+        args=["dcap-qvl"], returncode=0, stdout=qvl_report, stderr=""
+    )
+    with patch("verify.facts.subprocess.run", return_value=completed):
+        facts = _verify_quote_signature({"quote": "00"})
+    assert facts.quote_valid is True
+    assert facts.mrtd == "aa" * 48
+    assert facts.rtmr["rtmr3"] == "ee" * 48
+    assert facts.report_data == "ff" * 64
+
+    with patch("verify.facts.subprocess.run", side_effect=FileNotFoundError):
+        facts = _verify_quote_signature({"quote": "00"})
+    assert facts.quote_valid is False
+    assert facts.verification_error == "dcap-qvl is not installed or not on PATH"
+
+
+def test_garbage_quote_returns_fact_error():
+    from verify.facts import _verify_quote_signature
+
+    facts = _verify_quote_signature({"quote": "not-a-quote"})
+    assert facts.quote_valid is False
+    assert "not valid hexadecimal" in facts.verification_error
+
+
 if __name__ == "__main__":
     test_tampered_tree_hash_surfaces_mismatch_and_verify_returns()
     test_non_anchored_ecosystem_surfaces_chain_id_zero_no_crash()
@@ -442,4 +483,6 @@ if __name__ == "__main__":
     test_onchain_non_anchored()
     test_onchain_rpc_unreachable()
     test_onchain_rpc_failure_flows_into_facts_errors()
+    test_qvl_report_is_parsed_and_missing_tool_is_specific()
+    test_garbage_quote_returns_fact_error()
     print("\n=== ALL FACTS TESTS PASSED ===")


### PR DESCRIPTION
## What it does

Replaces the `quote_valid=false` skeleton with the real `dcap-qvl verify --hex <quote>` invocation. It parses the verified TDX report into MRTD/RTMR facts, reports missing or malformed tooling/quotes explicitly, and detects source-binding and approved-measurement mismatches.

## What you get by merging

Consumers can distinguish a genuine verified quote from an unavailable verifier, a bad quote, and genuine hardware running an unapproved compose/source binding.

## Story

Closes #93. Acceptance covered by this PR:

- `_verify_quote_signature()` invokes dcap-qvl and parses real TDX verification output.
- The good fixture verifies with `quote_valid=true`, empty `verification_error`, and MRTD/RTMR facts.
- Garbage/missing-tool and failed-quote paths return specific errors without raising.
- Tampered source binding is reported distinctly; approved compose/MRTD/RTMR comparison is explicit when supplied by the consumer.
- Install documentation is included in `verify.md`.

## Evidence (Tier 1)

- Focused verifier tests: `9 passed`.
- Real good fixture run: `quote_valid=True`, empty `verification_error`, MRTD plus `rtmr0`–`rtmr3` extracted.
- Tampered fixture run: `quote_valid=True` for the unchanged hardware quote, plus `source binding mismatch` for the altered tree hash.
- Full `test_daemon.py`: `ALL TESTS PASSED`.

## Verification

Backend-only — no visual evidence. The staging deployment and the pinned version-route transcript (the `version` route under `/_api/`) are credential-blocked from zed (details in the BLOCKED section below): `phala` there answers `Invalid API key` even on read-only calls, and `docker push` to ghcr is scope-denied.

## BLOCKED — need from operator:

Deploy `71f266c3` (this PR's head) to the **webhost-staging** CVM from a box holding the deploy credentials (the integrator/laptop), then paste into this PR **body** the transcript of a `GET` on the daemon's `version` route under `/_api/`, showing `"commit": "71f266c3"`. Verified state on zed as of 2026-08-16 that makes this operator-only:

- `phala` on zed: `Invalid API key` (read-only `phala status` / `phala runtime-config` both fail; re-checked this pass).
- `docker push ghcr.io/amiller/tee-socket-proxy` from zed: `denied: permission_denied: The token provided does not match expected scopes` (image `staging-71f266c3` is built locally on zed, awaiting push creds).
- The staging compose manifest is quarantined: `~/paseo-batch/overhaul-backup/docker-compose.webhost-staging.yaml.STALE-DANGEROUS-20260813`; `~/paseo-batch/staging-deploy.sh` expects a live `~/paseo-batch/docker-compose.webhost-staging.yaml`.
- Live webhost-staging still serves main-branch commit `39c54cc8` (version `dev`) — not even staging HEAD. The laptop deploy loop is otherwise alive: hermes-staging and the base-prod7 CVM were redeployed to main `fd0113fd` on 2026-08-16; only webhost-staging is being skipped.
- The dcap-qvl verifier work exists **only** on this branch (zero references in `origin/main` or `origin/staging` as of this pass) — there is no alternate route that lands it.

Operator sequence: check out `71f266c3` → reinstate a current staging compose → `~/paseo-batch/staging-deploy.sh` → paste the version-route transcript (`71f266c3`) into this body → then add `ready-to-merge` (tree at this commit: 20/20 verify tests pass, dcap-qvl real). This body deliberately spells the route non-literally so the merge gate's transcript grep can only ever fire on the pasted real transcript, never on this BLOCKED narrative — the paste-before-label ordering is enforced by the body itself, not by comment warnings.

## Risk / what to watch

`dcap-qvl` performs collateral retrieval unless the deployment supplies a reachable/cache-backed PCCS path; its absence is surfaced as an error and never treated as a failed-but-verified quote. The QVL CLI is installed with `cargo install dcap-qvl-cli`.

<details>
<summary>Diff stats and raw logs</summary>

`verify/facts.py`, `verify/test_facts.py`, and `verify.md`; `216 insertions(+), 15 deletions(-)`.

Full test output: `~/paseo-batch/out/93/test.log` on the worker host.

</details>


