### PR TITLE
staging-B: derive project-scoped oauth3 seal keys

### DIFF
--- a/examples/oauth3-staging-b/README.md
+++ b/examples/oauth3-staging-b/README.md
@@ -1,0 +1,16 @@
+# staging-b oauth3 core
+
+This deploys the same `oauth3-server/server` tree as the staging `oauth3` project under
+`/oauth3b`. The daemon gives each isolated project its own persistent data volume and derives
+`SEAL_KEY` from the project-scoped dstack path `/tee-daemon/projects/oauth3b/seal`; no key is
+committed or copied through the manifest.
+
+From a checkout with the staging credentials loaded:
+
+```sh
+source ~/.tee-daemon-staging.env
+OAUTH3_SERVER_DIR=~/projects/oauth3-server ./examples/oauth3-staging-b/deploy.sh
+```
+
+Verify both routes and compare the returned `tree_hash` values before using `oauth3b` as a
+migration destination.

--- a/examples/oauth3-staging-b/deploy.sh
+++ b/examples/oauth3-staging-b/deploy.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+OAUTH3_SERVER_DIR=${OAUTH3_SERVER_DIR:-"$HOME/projects/oauth3-server"}
+: "${TEE_DAEMON_URL:?source ~/.tee-daemon-staging.env first}"
+: "${TEE_DAEMON_TOKEN:?source ~/.tee-daemon-staging.env first}"
+
+test -f "$OAUTH3_SERVER_DIR/server/handler.ts"
+test -f "$OAUTH3_SERVER_DIR/server/project.json"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT
+tar -C "$OAUTH3_SERVER_DIR/server" -czf "$tmp/oauth3b.tgz" .
+
+curl --fail-with-body -sS -X POST "$TEE_DAEMON_URL/_api/projects" \
+  -H "Authorization: Bearer $TEE_DAEMON_TOKEN" \
+  -F "manifest=@$ROOT/examples/oauth3-staging-b/project.json;type=application/json" \
+  -F "files=@$tmp/oauth3b.tgz;type=application/gzip"

--- a/examples/oauth3-staging-b/project.json
+++ b/examples/oauth3-staging-b/project.json
@@ -1,0 +1,18 @@
+{
+  "name": "oauth3b",
+  "runtime": "deno",
+  "entry": "handler.ts",
+  "isolation": "container",
+  "mode": "attested",
+  "env": {
+    "POLL_INTERVAL_MIN": "30"
+  },
+  "env_passthrough": [
+    "OAUTH3_OWNER_SECRET",
+    "BROWSER_SPI_URL",
+    "BROWSER_SPI_SECRET"
+  ],
+  "dstack_env": {
+    "SEAL_KEY": "seal"
+  }
+}

--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -345,6 +345,7 @@ async def deploy(store: ProjectStore, docker: DockerClient, audit_manager,
         source=source, ref=ref, commit_sha=commit_sha, tree_hash=tree_hash,
         listen=listen_config, isolation=isolation,
         env_passthrough=manifest.get("env_passthrough") or repo_manifest.get("env_passthrough", []) or [],
+        dstack_env=manifest.get("dstack_env") or repo_manifest.get("dstack_env", {}) or {},
         oci_runtime=manifest.get("oci_runtime", ""),
         cap_add=cap_add, devices=devices, operator_debug=operator_debug,
     )

--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -773,6 +773,7 @@ class Ingress:
             "isolation": project.isolation,
             "image": project.image, "image_port": project.image_port,
             "volumes": project.volumes, "env_passthrough": project.env_passthrough,
+            "dstack_env": project.dstack_env,
             "oci_runtime": project.oci_runtime,
         }
         if project.listen:

--- a/proxy/projects.py
+++ b/proxy/projects.py
@@ -36,6 +36,7 @@ class Project:
     volumes: List[dict] = field(default_factory=list)
     isolation: str = "shared"
     env_passthrough: List[str] = field(default_factory=list)
+    dstack_env: dict = field(default_factory=dict)
     oci_runtime: str = ""  # per-project OCI runtime, e.g. "runsc" (gVisor); falls back to CONTAINER_RUNTIME
     # Elevated container capabilities — honored ONLY for mode=="attested" projects (see
     # deploy gate), so the grant is always on the verifiable attested surface. Used e.g.

--- a/proxy/runtimes.py
+++ b/proxy/runtimes.py
@@ -1,9 +1,14 @@
 """Shared runtime containers — one per runtime type, routes all projects."""
 
 import json
+import hashlib
+import hmac
 import logging
 import os
+import re
 import secrets
+
+import aiohttp
 
 from .docker_client import DockerClient
 from .projects import ProjectStore
@@ -39,6 +44,49 @@ DATA_VOLUME_MOUNT_IN_RUNTIME = "/daemon-data"
 BROKER_HOST_PATH = os.environ.get("BROKER_HOST_PATH", "")
 BROKER_MOUNT_IN_APP = "/run/broker"
 IMAGE_APP_RESTART_POLICY = {"Name": "on-failure", "MaximumRetryCount": 5}
+DSTACK_SOCKET = os.environ.get("DSTACK_SOCKET", "/var/run/dstack.sock")
+_DSTACK_ENV_NAME = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+_DSTACK_KEY_NAME = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _hkdf(ikm: bytes, info: bytes, length: int = 32) -> bytes:
+    prk = hmac.new(b"", ikm, hashlib.sha256).digest()
+    out = b""
+    previous = b""
+    for counter in range(1, 256):
+        previous = hmac.new(prk, previous + info + bytes([counter]), hashlib.sha256).digest()
+        out += previous
+        if len(out) >= length:
+            return out[:length]
+    raise ValueError("HKDF output too long")
+
+
+async def _resolve_dstack_env(project) -> dict:
+    """Derive project-scoped environment values from dstack GetKey."""
+    resolved = {}
+    if not project.dstack_env:
+        return resolved
+    if not os.path.exists(DSTACK_SOCKET):
+        raise RuntimeError(f"dstack socket unavailable for project {project.name}")
+    conn = aiohttp.UnixConnector(path=DSTACK_SOCKET)
+    async with aiohttp.ClientSession(connector=conn) as session:
+        for env_name, key_name in project.dstack_env.items():
+            if not _DSTACK_ENV_NAME.fullmatch(env_name) or not isinstance(key_name, str) or not _DSTACK_KEY_NAME.fullmatch(key_name):
+                raise ValueError(f"invalid dstack_env entry for project {project.name}")
+            path = f"/tee-daemon/projects/{project.name}/{key_name}"
+            async with session.post("http://localhost/GetKey", json={"path": path}) as resp:
+                if resp.status != 200:
+                    raise RuntimeError(f"GetKey failed for {path}: {resp.status}")
+                data = await resp.json()
+            key_hex = str(data.get("key", "")).replace("0x", "")
+            try:
+                ikm = bytes.fromhex(key_hex)
+            except ValueError as exc:
+                raise RuntimeError(f"GetKey returned invalid key for {path}") from exc
+            if len(ikm) < 32:
+                raise RuntimeError(f"GetKey returned a short key for {path}")
+            resolved[env_name] = _hkdf(ikm[:32], f"tee-daemon/env/v1/{env_name}".encode()).hex()
+    return resolved
 
 
 def _project_uses_broker(project) -> bool:
@@ -519,6 +567,7 @@ class RuntimeManager:
             val = os.environ.get(key)
             if val is not None:
                 env[key] = val
+        env.update(await _resolve_dstack_env(project))
 
         # Inject broker socket path and token if project uses broker
         if uses_creds:
@@ -587,6 +636,8 @@ class RuntimeManager:
             val = os.environ.get(key)
             if val is not None:
                 env.append(f"{key}={val}")
+        for key, val in (await _resolve_dstack_env(project)).items():
+            env.append(f"{key}={val}")
 
         # Inject broker socket path and token if project uses broker
         if uses_creds:


### PR DESCRIPTION
## What it does
Adds project-scoped dstack key derivation for isolated projects and provides the `oauth3b` staging deployment manifest/script. `oauth3b` derives `SEAL_KEY` from `/tee-daemon/projects/oauth3b/seal` and gets its own persistent project data volume.

## What you get by merging
A reproducible, secret-free deployment path for a second oauth3 core at `/oauth3b`, with a distinct dstack-derived seal key and disjoint data directory.

## Story
Issue: #103

Acceptance to verify after staging deploy:
- `/oauth3b` health/version and login work like `/oauth3`.
- A subject/data record created on A is absent on B.
- Both projects have the same code identity.
- Tier 1 transcript includes both versions and the disjoint-data check.

## Evidence (Tier 1)
Local `test_daemon.py` passed completely (`=== ALL TESTS PASSED ===`). The required deployed-staging transcript is not yet available: building `ghcr.io/amiller/tee-socket-proxy:staging-c433bdcc` succeeded, but pushing it was rejected because the available registry token lacks `packages:write`.

## Risk / what to watch
Do not deploy `examples/oauth3-staging-b/project.json` until the daemon image containing `dstack_env` support is running. The deploy script never puts secrets in the repository; it packages the selected oauth3 server tree and relies on staging daemon secrets plus the project-scoped dstack key.

## BLOCKED — need from operator:
A GHCR credential with `packages:write` (or operator deployment of commit `c433bdcc` to `webhost-staging`), followed by the issue #103 Tier 1 transcript.

<details>
<summary>Diff stats</summary>

7 files changed, 107 insertions(+).

</details>