### PR TITLE
docs(0019): finish RFC 0019 to reviewable — Motivation/Design/Deployment/MVP slice (#22)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,15 @@
+# Issue #22 plan
+
+- [x] Restructure `rfcs/0019-managed-hosting-teesql.md` into reviewable form: named
+      Motivation, Design (with TeeSQL data model + AttestMesh topology subsections),
+      Deployment story, and Open Questions sections, each substantive, preserving the
+      existing pitch content (Context, what each side brings, options a/b, constraints).
+- [x] No TODO/TBD placeholders anywhere in the RFC.
+- [x] End the RFC with an MVP slice section naming the first implementable step
+      (option (a) pilot: one managed base-prod dstack node, mesh unused, RFC 0017
+      durability floor) and its own checkable acceptance criteria, so the next
+      tracking issue can be filed against it.
+- [x] Tier 0: documentation only, no behavior change — no code touched.
+
+Operator verification remains: review the rendered RFC; the follow-up tracking issue
+against the MVP slice is the operator's to file.

--- a/rfcs/0019-managed-hosting-teesql.md
+++ b/rfcs/0019-managed-hosting-teesql.md
@@ -5,9 +5,11 @@ Run dstack-webhost as a managed, multi-tenant service on infrastructure TeeSQL
 operates (their AttestMesh mesh and dstack nodes), so the hosting/ops burden moves
 to them while we keep the app and the attestation-appraisal layer. dstack-webhost
 stays open and self-hostable for personal use; the managed deployment is the paid,
-multi-tenant version. This is a request for collaboration, not a committed design.
+multi-tenant version. This is a request for collaboration: the design below is
+reviewable, but the (a)/(b) topology choice and the commercial model are decided
+with TeeSQL, not unilaterally here.
 
-## Context
+## Motivation
 Two gaps line up:
 
 - **Ours.** dstack-webhost is a single-CVM host. Durability and fleet recovery are
@@ -23,58 +25,118 @@ A multi-tenant attestable-app host is a genuine stateful-cluster use of the mesh
 dstack-webhost on AttestMesh gives them their first real app and gives us a managed,
 reliable substrate.
 
-## What we bring
-- **dstack-webhost** — the multi-tenant app host (deploy via git/API, dev →
+What each side brings:
+
+- **We bring dstack-webhost** — the multi-tenant app host (deploy via git/API, dev →
   attested-promotion, per-tenant isolation), unchanged for self-host and adapted for
-  the managed/clustered deployment.
-- **Attestation appraisal** — independent validation and explanation of each hosted
-  app's attestation path, distilled from existing research practice into a repeatable
-  workflow. This is the differentiated value the managed service sells on top of raw
-  hosting; its audience is the customer's customer (the relying party).
+  the managed/clustered deployment — and the **attestation appraisal**: independent
+  validation and explanation of each hosted app's attestation path, distilled from
+  existing research practice into a repeatable workflow. The appraisal is the
+  differentiated value the managed service sells on top of raw hosting; its audience
+  is the customer's customer (the relying party).
+- **We ask TeeSQL to operate the metal** — run and keep up the dstack nodes and the
+  mesh on an on-chain-anchored ecosystem (base-prod; see Constraints), owning
+  deploys, upgrades, health, and recovery — **to provide the reliability primitives
+  we'd otherwise build** (same-`app_id` replicas behind the gateway's existing
+  health-routing for HA; durable per-tenant state that survives CVM recreation), and
+  **to let the appraisal lean on AttestMesh's attestation machinery** (the on-chain
+  KMS sig-chain verification, the attested indexer, its RPC-repro-stub pattern)
+  rather than re-implementing it.
 
-## What we're asking TeeSQL for
-1. **Operate the metal.** Run and keep up the dstack nodes and the AttestMesh mesh on
-   an on-chain-anchored ecosystem (base-prod — see Constraints). Own deploys,
-   upgrades, health, and recovery.
-2. **Provide the reliability primitives we'd otherwise build.** Same-app_id replicas
-   behind the gateway's existing health-routing for HA; durable per-tenant state that
-   survives CVM recreation (the externalized-volume / pinned-restore shape of RFC
-   0017, or in-mesh shared state keyed by the CSK — see Options).
-3. **Let the appraisal lean on AttestMesh's attestation machinery.** The on-chain KMS
-   sig-chain verification, the attested indexer, and its RPC-repro-stub pattern
-   already cover much of what an attestation appraisal needs as a verification
-   backend. We'd build the appraisal on top rather than re-implement it.
+## Design
 
-## Product shape
-- **Managed multi-tenant service** — dstack-webhost on TeeSQL-operated AttestMesh,
-  that others sign up for, with the attestation appraisal per hosted app.
-- **Self-hostable** — dstack-webhost stays open and easy to run on your own dstack
-  box, as today. Open-core: same codebase, two deployment modes.
+### TeeSQL data model
+The unit of tenancy is a dstack-webhost instance (one daemon) owning N projects. The
+atom is the `Project` manifest (`proxy/projects.py`): `name`, `runtime`, `entry`,
+`port`, `mode` (dev/attested), the source pins (`source`/`ref`/`commit_sha`/
+`tree_hash`, `image`/`image_digest`), `volumes`, and the per-app attestation fields
+(`app_id`, `app_pubkey`, `binding_quote`, `attestation_kind`). Private app state
+lives in the per-project data volume (`/daemon-data/<name>`); secrets live in `env`
+and are the credential broker's problem (RFC 0018), not the host store's.
 
-## Architecture options (decide together)
+- **Self-host (today):** manifests on the daemon volume, code pinned by
+  commit/tree_hash, everything CVM-local. Single-CVM blast radius; RFC 0017's
+  external named volumes plus export/import are the durability floor.
+- **Managed, option (a):** the identical model on a TeeSQL-operated node; no state
+  moves and no new store exists.
+- **Managed, option (b):** the manifest registry becomes mesh-shared state keyed by
+  the cluster shared key (CSK) — membership-encrypted replication across webhost
+  members — and per-tenant `dataDir`s are sealed blobs restorable only inside the
+  same app identity. RFC 0017's export bundle is the canonical serialization in
+  transit and the bootstrap artifact when a member joins: a new member restores from
+  the bundle during `recover_all()` before it serves traffic.
+
+What TeeSQL holds vs. never holds: they operate nodes, volumes, and the mesh, but no
+plaintext tenant secret ever reaches them — `env` stays behind RFC 0018 grants /
+dstack KMS-derived keys — and manifests plus pins are public-safe metadata (the RFC
+0015 verification surface already publishes them for attested projects).
+
+### AttestMesh topology
+- **Edge:** the gateway, unchanged — health-routed, `zt-cert` quote pinned; this is
+  the channel layer an appraisal consumer checks first.
+- **Members:** dstack-webhost daemons as AttestMesh cluster members. HA is
+  same-`app_id` replicas behind the gateway's existing health routing; coordination
+  (which member owns a project's container, membership churn) runs over the mesh
+  under the CSK.
+- **Anchoring:** membership and attestation are anchored on-chain on Base mainnet
+  (base-prod). The on-chain KMS sig-chain verification and the attested indexer
+  serve as the verification backend for the mesh itself, and our appraisal layer
+  builds on them — the indexer's repro-stub pattern is the same posture RFC 0020
+  requires of evidence consumers, so we extend rather than duplicate.
+- **Granularity:** a shared instance is daemon-vouched (`attestation_kind:
+  "daemon-vouched"` — the hardware quote attests the webhost, which vouches project
+  → tree_hash); a tenant that needs a hardware quote of the app itself gets a
+  per-app CVM (`"app-cvm"`). Granularity is a per-tenant deployment choice, not a
+  platform fork.
+
+### Architecture options (decide together)
 - **(a) Managed dstack nodes, mesh unused.** TeeSQL runs dstack nodes; we deploy
-  dstack-webhost onto them as ordinary apps. Simplest, fastest start; the mesh is not
-  load-bearing.
-- **(b) dstack-webhost as a real AttestMesh cluster.** Multiple webhost members in an
-  AttestMesh cluster, per-tenant durable state keyed by the CSK, mesh for
-  coordination. More work, but it's the stronger joint story (their mesh actually
-  carries the app) and gives HA + shared state natively.
+  dstack-webhost onto them as ordinary apps. Simplest, fastest start; the mesh is
+  not load-bearing.
+- **(b) dstack-webhost as a real AttestMesh cluster.** Multiple webhost members in
+  one cluster, per-tenant durable state keyed by the CSK, mesh for coordination.
+  More work, but the stronger joint story (their mesh actually carries the app) and
+  HA + shared state natively.
 
 Recommendation: start with (a) to get live, with (b) as the target once it's a real
 product. Their input decides this, since they operate it.
 
-## Working model (open)
-- Whether this is a flat managed-infra fee, a revenue share on the service, or a
-  deeper partnership.
-- Who owns the tenant relationship, billing, and signups (default: we do; TeeSQL is
-  invisible infra).
-- Whether the appraisal is co-branded or ours alone.
+## Deployment story
+One codebase, two deployment modes (open core):
 
-## Open questions
-- (a) vs (b) above.
+- **Self-host** stays exactly as today: a single CVM, `docker-compose.yaml`, no
+  mesh, no TeeSQL. Any change that complicates the self-host path is out of scope.
+- **Managed bring-up (option a):**
+  1. TeeSQL stands up dstack node(s) on a base-prod ecosystem.
+  2. dstack-webhost itself is deployed there as an *attested* app — promoted through
+     the same dev → attested gate as any tenant app, `app_id` from the on-chain
+     `DstackApp` allowlist, binding quote recorded (the RFC 0025 machinery,
+     unchanged).
+  3. External named volumes are wired per RFC 0017's operational requirement, and
+     export/import is enabled — this is the whole recovery story until (b) exists.
+  4. Tenants onboard through the existing `/_api` deploy + promotion; nothing in the
+     tenant path differs between modes.
+  5. Upgrades: a new pinned webhost image, deployed and re-promoted like any other
+     version — the pin is the upgrade contract; no in-place mutation.
+  6. Recovery: RFC 0017 pinned restore — fresh CVM, import bundle, `recover_all()`
+     rebuilds the fleet at recorded pins, refusing (never re-cloning latest) on pin
+     mismatch. In (b) the same restore runs mesh-side keyed by the CSK.
+
+**Ownership:** we own the tenant relationship, billing, and signups by default;
+TeeSQL is invisible infra. The appraisal is ours; co-branding is an open question.
+
+**Migration (a) → (b):** the RFC 0017 export bundle is carried across verbatim — it
+is the compatibility contract between the two options, so no bespoke migration
+format ever exists.
+
+## Open Questions
+- (a) vs. (b) — and if (b), the ownership/coordination protocol details on the mesh.
 - Which base-prod ecosystem, and whether our existing creds/accounts reach it.
 - How much of the appraisal AttestMesh's primitives cover vs. we build.
 - Operational expectations for "reliable": recovery time, replica count, SLA.
+- Commercial model: flat managed-infra fee, revenue share on the service, or a
+  deeper partnership.
+- Whether the appraisal is co-branded or ours alone.
 
 ## Out of scope
 - The internal design of the durable-state layer (RFC 0017 / a follow-up).
@@ -86,3 +148,34 @@ product. Their input decides this, since they operate it.
   anchored on Base mainnet) requires a base-prod ecosystem. pha-prod returns
   chain_id 0 / no KMS contract and is a dev placeholder; the managed service must not
   run there.
+
+## MVP slice
+First implementable step: **option (a) pilot — one managed base-prod dstack node,
+mesh unused, durability floor wired.** TeeSQL operates the node in production; any
+base-prod dstack node qualifies to prove the slice (a self-operated one stands in
+until theirs exists).
+
+Our side, implementable now:
+1. RFC 0017 export/import plus the external-named-volume requirement land — this is
+   the pilot's recovery path (prerequisite, tracked under RFC 0017).
+2. Deploy dstack-webhost as an attested app on that node, promoted through the
+   normal gate, so the hosting layer is itself attestable — the managed pitch's
+   proof point.
+3. Document the managed bring-up runbook (the steps above) in-repo; credentials
+   stay out of the repo entirely.
+
+Acceptance criteria for the slice:
+- The managed host serves `GET /_api/version` pinned to this repo's commit, and its
+  public RFC 0015 endpoints (`/_api/attest/<name>`, `/_api/verification/<name>`)
+  return a valid binding (`app_id`, `tree_hash`, quote) for the daemon's own
+  attested deployment.
+- One tenant app deployed and promoted through `/_api` on the managed host verifies
+  end-to-end via the same public endpoints.
+- Export → destroy → import on the managed host restores the fleet at identical
+  pins; a tampered pin errors, never silently re-clones.
+- No mesh dependency: the pilot runs with AttestMesh absent — that is the definition
+  of option (a).
+
+The option (b) cluster work (CSK-keyed shared state, mesh coordination, HA
+replicas) is a follow-up tracking issue filed against this section, not part of the
+slice.


### PR DESCRIPTION
## What it does
Finishes `rfcs/0019-managed-hosting-teesql.md` from a pitch stub to a reviewable RFC: the acceptance-named sections — **Motivation**, **Design** (TeeSQL data model + AttestMesh topology + options a/b), **Deployment story**, **Open Questions** — each substantive with no TODO/TBD placeholders, and the RFC now **ends with an MVP slice** (option-(a) pilot) carrying its own checkable acceptance criteria.

## What you get by merging
A RFC 0019 you can actually review and hand to TeeSQL, plus a concrete first implementable step (single managed base-prod dstack node, mesh unused, RFC 0017 durability floor) precise enough to file the next tracking issue against.

## Story
Closes #22 (tracking issue). Its `## Acceptance`:
- [x] RFC 0019 reviewable, not a Draft stub: Motivation, Design (TeeSQL data model + AttestMesh topology), Deployment story, Open Questions each substantive, no TODO/TBD placeholders.
- [x] RFC ends with an **MVP slice** section naming the first implementable step and its own acceptance criteria.

All existing pitch content (Context, what each side brings, options a/b, base-prod constraint, open questions) is preserved and folded into the new structure — nothing was dropped.

## Evidence — Tier 0: no behavior change
Documentation only: one RFC rewrite plus `PLAN.md`; zero code files touched, so there is nothing to deploy or walk. The verification gate still ran green: `test_daemon.py` (real docker) → `=== ALL TESTS PASSED ===` on this branch's commit. Backend-only — no visual evidence (nothing user-visible changed).

## Risk / what to watch
Low. The design content beyond what staging already implements (mesh-shared CSK state, appraisal-on-indexer) is stated as target shape under option (b), not as built — the MVP slice deliberately requires no mesh. RFC 0017 export/import is named as a prerequisite and is still in review (PR #107); the slice's recovery criterion depends on that landing.

<details>
<summary>Diff stats + test log tail</summary>

```
 PLAN.md                             |  15 +++
 rfcs/0019-managed-hosting-teesql.md | 181 +++++++++++++++++++++++++++---------
 2 files changed, 152 insertions(+), 44 deletions(-)
```

```
  Torn down: test-opdebug-off
  Torn down: tier0-src
  All projects removed ✓

=== ALL TESTS PASSED ===
```
Full log: `~/paseo-batch/out/22/test.log` (box path; the tier-0 evidence itself is the statement above + green suite).
</details>
