### PR TITLE
version identity: bake GIT_COMMIT via compose args, assert at build and boot (#106)

### DIFF
--- a/.evidence/issue-106/transcript.md
+++ b/.evidence/issue-106/transcript.md
@@ -103,3 +103,18 @@ vs staging is unchanged from the original PR. At rebased commit ad12059e:
   (box-local, not committed).
 
 §5 operator steps are unchanged.
+
+## 7. SHA correction: verification re-anchored at the pushed head 856f3638 (rework, 2026-08-18)
+
+§6 ran at `ad12059e`, which was never pushed: appending §6 amended the commit, so
+the branch landed as `856f3638` (single commit on origin/staging-106). `ad12059e`
+still exists in the local repo and `git diff ad12059e 856f3638` is exactly §6 —
+no code difference. The §6 suite run therefore covered this tree minus this
+evidence file. Re-anchored at the pushed head:
+
+- `GIT_COMMIT=856f3638 docker compose build` → succeeds.
+- bare `docker compose build` → exit 1 at the Dockerfile guard, §1's message verbatim.
+- image run on :18081, real HTTP: `curl http://localhost:18081/_api/version` →
+  `{"version": "dev", "commit": "856f3638"}` (HTTP 200).
+- `docker run --rm -e DAEMON_COMMIT= ...` → the §3 boot refusal, verbatim.
+

--- a/.evidence/issue-106/transcript.md
+++ b/.evidence/issue-106/transcript.md
@@ -1,0 +1,105 @@
+# Issue #106 — version identity baked at build, asserted at boot — evidence (Tier 1)
+
+All commands run on zed from the `staging-106` worktree at commit below.
+Artifact NOT pushed from this box: the stored ghcr credential is read-only
+("denied: permission_denied: The token provided does not match expected scopes")
+and the phala API key is dead (401). Build+push+deploy are operator steps (§5).
+
+## 1. Misbuild now fails at BUILD time (was: silent empty DAEMON_COMMIT)
+
+`docker compose build` without GIT_COMMIT (i.e. the bare `build: .` path the issue
+describes — compose args are now the only way to pass it):
+
+```
+ > [tee-daemon 7/7] RUN test -n "" || { echo >&2 "ERROR: GIT_COMMIT build arg is empty — bake the commit being built: docker build --build-arg GIT_COMMIT=<short-sha> . (or docker-compose.yaml build.args)"; exit 1; }:
+0.197 ERROR: GIT_COMMIT build arg is empty — bake the commit being built: docker build --build-arg GIT_COMMIT=<short-sha> . (or docker-compose.yaml build.args)
+failed to solve: process "/bin/sh -c test -n \"$GIT_COMMIT\" ..." did not complete successfully: exit code: 1
+```
+
+Plain ad-hoc `docker build` (no compose, no --build-arg — the class of script that
+burned staging) fails identically, because the guard lives in the Dockerfile:
+
+```
+$ docker build -t tee-daemon:nocommit .
+ERROR: failed to solve: process "/bin/sh -c test -n \"$GIT_COMMIT\" || ..." did not complete successfully: exit code: 1
+```
+
+## 2. Compose-built image serves its baked commit over HTTP
+
+```
+$ GIT_COMMIT=<commit> docker compose build
+$ docker run -d --name vercheck-106 -p 18081:18081 \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -e INGRESS_PORT=18081 -e DSTACK_SOCKET=/nonexistent \
+    -e DAEMON_DATA_DIR=/tmp/vd -e DAEMON_AUDIT_DIR=/tmp/va -e DAEMON_TUNNEL_DIR=/tmp/vt \
+    -e DAEMON_TOKEN_DIR=/tmp/vto -e DAEMON_BROKER_DIR=/tmp/vb -e DAEMON_CREDS_DIR=/tmp/vc \
+    -e PROXY_SOCKET_DIR=/tmp/vp -e BROKER_SOCKET_DIR=/tmp/vbr \
+    -e TEE_DAEMON_TOKEN=test-token-106 rw-106-tee-daemon:latest
+$ curl -s http://localhost:18081/_api/version
+{"version": "dev", "commit": "f3867048"}        # == the GIT_COMMIT passed to compose build
+```
+
+(transcript from the wiring check at staging HEAD f3867048; the pushed artifact
+below is rebuilt from the branch commit after committing, same procedure)
+
+## 3. Boot refusal when DAEMON_COMMIT is blanked by env (in-container)
+
+An env override beats the baked value; an empty one now kills the daemon at boot
+instead of 500ing per-request:
+
+```
+$ docker run --rm -e DAEMON_COMMIT= rw-106-tee-daemon:latest
+RuntimeError: DAEMON_COMMIT is empty and no .git is present: this image was built
+without the GIT_COMMIT build arg (docker-compose.yaml build.args, or docker build
+--build-arg GIT_COMMIT=<short-sha>). Refusing to start rather than report an
+unknown commit on /_api/version (issue #106).
+```
+
+## 4. Local-dev git path only where .git exists (test_daemon.py)
+
+```
+--- Test: version endpoint ---
+  Version: dev commit: f3867048 ✓            # == git rev-parse --short HEAD of the running tree
+--- Test: daemon refuses to boot without a commit identity ---
+  Refused at boot: RuntimeError: DAEMON_COMMIT is empty and no .git is present: ... ✓
+=== ALL TESTS PASSED ===
+```
+
+Full suite log: `~/paseo-batch/out/106/test.log` (not committed; box-local).
+
+## 5. Operator steps (cannot run from zed)
+
+The stored ghcr credential is read-only (push denied) and the phala API key on this
+box is dead (401 on cvms ls); the staging compose file is not on this box
+(box-inventory: operator-run). To finish acceptance (c):
+
+1. from the merged branch:
+   `docker build --build-arg GIT_COMMIT=$(git rev-parse --short HEAD) -t ghcr.io/amiller/tee-socket-proxy:staging-$(git rev-parse --short HEAD) . && docker push ghcr.io/amiller/tee-socket-proxy:staging-$(git rev-parse --short HEAD)`
+   (or `GIT_COMMIT=... docker compose build` — same result, that is acceptance (a)),
+2. point the staging compose at the new digest and REMOVE the hand-maintained
+   `DAEMON_COMMIT=39c54cc8` literal from the daemon service `environment:` first —
+   env beats the baked value and would mask the new commit,
+3. `phala deploy --cvm-id webhost-staging ...`, then
+   `curl /_api/version` → 200 with commit == the pushed source tree's commit.
+
+Note: the misbuilt-image guard makes step 1 fail loudly if the arg is forgotten —
+that is the whole point of the change.
+
+## 6. Re-verified after rebase onto staging (rework, 2026-08-18)
+
+Rebased onto origin/staging (5 commits: RFC 0017 export/import, dcap-qvl quote
+verification, on-chain app approval, runsc Dns, evidence cleanup). Only PLAN.md
+conflicted — resolved as the union of the per-issue plan sections; the code diff
+vs staging is unchanged from the original PR. At rebased commit ad12059e:
+
+- `docker build .` and `docker compose build`, both without GIT_COMMIT: fail at
+  the Dockerfile guard (exit 1), same message as §1.
+- `GIT_COMMIT=ad12059e docker compose build`, then real HTTP:
+  `curl http://localhost:18081/_api/version` → `{"version": "dev", "commit": "ad12059e"}` (HTTP 200).
+- `docker run --rm -e DAEMON_COMMIT= ...` → the §3 boot refusal, verbatim.
+- Full `test_daemon.py` under flock: `=== ALL TESTS PASSED ===`, including the
+  version test pinning `/_api/version`'s commit to the running tree (`ad12059e`)
+  and the boot-refusal test. Log: `~/paseo-batch/out/106/test-rebased.log`
+  (box-local, not committed).
+
+§5 operator steps are unchanged.

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ COPY proxy/ /app/proxy/
 COPY verify/__init__.py verify/bundle.py /app/verify/
 WORKDIR /app
 ARG GIT_COMMIT
+# A missing identity must fail HERE, at build time, on every build path (compose,
+# ad-hoc docker build, CI) — not hours later as a 500 on /_api/version (issue #106).
+RUN test -n "$GIT_COMMIT" || { echo >&2 "ERROR: GIT_COMMIT build arg is empty — bake the commit being built: docker build --build-arg GIT_COMMIT=<short-sha> . (or docker-compose.yaml build.args)"; exit 1; }
 ENV DAEMON_COMMIT=$GIT_COMMIT
 EXPOSE 8080
 ENTRYPOINT ["python", "-m", "proxy.main"]

--- a/PLAN.md
+++ b/PLAN.md
@@ -75,3 +75,21 @@ it (isolated, image-runtime, browser pool).
 
 Operator verification remains: provide the base-prod RPC/contract configuration and deploy the
 consumer-facing verifier path to staging for the required pinned `/_api/version` transcript.
+# Issue #106 plan — version identity baked at build, asserted at boot
+
+- [x] (a) `docker-compose.yaml` `build:` gains an `args:` block supplying `GIT_COMMIT`,
+      so `docker compose build` bakes `DAEMON_COMMIT` without depending on `ship-fix.sh`.
+- [x] (a+) `Dockerfile` asserts `GIT_COMMIT` is non-empty at build time — every build
+      path (compose, ad-hoc `docker build`, CI) now fails loudly instead of baking `""`.
+- [x] (b) `proxy/main.py` resolves the commit once at boot and **refuses to start**
+      when `DAEMON_COMMIT` is empty/unset and no `.git` is present (local-dev git read
+      stays, but only where `.git` exists; its absence is a hard error).
+- [x] (b) `proxy/ingress.py:_api_version` drops the request-time `git rev-parse`
+      fallback — identity is settled at boot or the process is already dead; a
+      request-time fallback could only ever mask a broken deploy.
+- [x] Tests: `test_daemon.py` pins `/​_api/version`'s commit to the running tree and
+      adds a boot-refusal test (misbuilt image exits non-zero with a clear message).
+- [ ] (c) Fresh staging deploy build→push→`phala deploy`→`GET /_api/version`: build
+      + local HTTP serve verified; push (read-only ghcr token) and `phala deploy`
+      (dead API key) are operator steps — exact commands in
+      `.evidence/issue-106/transcript.md` §5.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,10 +3,15 @@
 #   phala deploy --cvm-name <name> -c docker-compose.yaml -e .env
 #
 # Local dev:
-#   docker compose up
+#   GIT_COMMIT=$(git rev-parse --short HEAD) docker compose up --build
+#   (GIT_COMMIT is asserted non-empty by the Dockerfile; an unset value fails the
+#   build rather than baking an image that cannot say what it is — issue #106)
 services:
   tee-daemon:
-    build: .
+    build:
+      context: .
+      args:
+        - GIT_COMMIT=${GIT_COMMIT:-}
     ports:
       - "8080:8080"
     volumes:

--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -525,16 +525,14 @@ class Ingress:
         }
 
     def _api_version(self) -> dict:
-        """Return daemon version and git commit. In a built image DAEMON_COMMIT is
-        baked at build time (no .git present); locally it falls to a git read."""
-        commit = os.environ.get("DAEMON_COMMIT")
-        if not commit:
-            import subprocess
-            commit = subprocess.check_output(
-                ["git", "rev-parse", "--short", "HEAD"],
-                cwd=os.path.dirname(os.path.dirname(__file__)),
-            ).decode().strip()
-        return {"version": os.environ.get("DAEMON_VERSION", "dev"), "commit": commit}
+        """Return daemon version and git commit. Identity is resolved and
+        validated once at boot (proxy.main._resolve_commit): baked from the
+        build arg in an image, read from git when running from a checkout.
+        No request-time fallback — it could only mask a broken deploy."""
+        return {
+            "version": os.environ.get("DAEMON_VERSION", "dev"),
+            "commit": os.environ["DAEMON_COMMIT"],
+        }
 
     def _public_attested_path(self, path: str) -> str | None:
         """RFC 0015: return project name if `path` is a public verifier endpoint."""

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -4,6 +4,7 @@ import asyncio
 import logging
 import os
 import signal
+import subprocess
 
 from aiohttp import web
 
@@ -40,7 +41,35 @@ CREDS_DIR = os.environ.get("DAEMON_CREDS_DIR", "/var/lib/tee-daemon/creds")
 INGRESS_PORT = int(os.environ.get("INGRESS_PORT", "8080"))
 
 
+def _resolve_commit() -> str:
+    """Version identity, resolved once at boot (issue #106).
+
+    In a built image DAEMON_COMMIT is baked from the Dockerfile's GIT_COMMIT
+    build arg (which the Dockerfile asserts non-empty). Unset means local dev
+    from a checkout, where git supplies it — but only if .git is actually
+    present. Refusing to run beats reporting a wrong/empty commit: /_api/version
+    anchors Tier-1 evidence, and a placeholder would silently poison every
+    claim that cites it.
+    """
+    commit = os.environ.get("DAEMON_COMMIT", "").strip()
+    if commit:
+        return commit
+    root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    if not os.path.exists(os.path.join(root, ".git")):
+        raise RuntimeError(
+            "DAEMON_COMMIT is empty and no .git is present: this image was "
+            "built without the GIT_COMMIT build arg (docker-compose.yaml "
+            "build.args, or docker build --build-arg GIT_COMMIT=<short-sha>). "
+            "Refusing to start rather than report an unknown commit on "
+            "/_api/version (issue #106).")
+    return subprocess.check_output(
+        ["git", "-C", root, "rev-parse", "--short", "HEAD"]).decode().strip()
+
+
 async def start():
+    # Boot-order matters: identity first, so a misbuilt image dies HERE, loudly,
+    # before any socket/container/port work makes it look alive.
+    os.environ["DAEMON_COMMIT"] = _resolve_commit()
     os.makedirs(PROXY_DIR, exist_ok=True)
     os.makedirs(BROKER_SOCKET_DIR, exist_ok=True)
 

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -186,7 +186,31 @@ def test_version():
     assert "commit" in data, f"commit field missing: {data}"
     assert isinstance(data["version"], str)
     assert isinstance(data["commit"], str)
+    # Identity must be TRUE, not merely present: the daemon runs from this
+    # checkout (no DAEMON_COMMIT baked), so its git read must match ours.
+    expected = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        capture_output=True, text=True, check=True).stdout.strip()
+    assert data["commit"] == expected, \
+        f"commit mismatch: /_api/version says {data['commit']!r}, tree is {expected!r}"
     print(f"  Version: {data['version']} commit: {data['commit']} ✓")
+
+
+def test_boot_refuses_without_commit():
+    print("\n--- Test: daemon refuses to boot without a commit identity ---")
+    # A misbuilt image has no DAEMON_COMMIT and no .git; boot must fail loudly
+    # there, not 500 on /_api/version at some later audit request (issue #106).
+    bare = tempfile.mkdtemp(prefix="tee-daemon-nogit-")
+    repo = os.path.dirname(os.path.abspath(__file__))
+    for pkg in ("proxy", "verify"):
+        os.symlink(os.path.join(repo, pkg), os.path.join(bare, pkg))
+    env = {k: v for k, v in os.environ.items() if k != "DAEMON_COMMIT"}
+    p = subprocess.run([sys.executable, "-m", "proxy.main"], cwd=bare, env=env,
+                       capture_output=True, text=True, timeout=120)
+    assert p.returncode != 0, "daemon must refuse to start without DAEMON_COMMIT"
+    assert "DAEMON_COMMIT" in p.stderr, f"unclear refusal message: {p.stderr[-500:]}"
+    refusing = [l for l in p.stderr.splitlines() if "DAEMON_COMMIT" in l][-1].strip()
+    print(f"  Refused at boot: {refusing} ✓")
 
 
 def test_deploy_static():
@@ -1591,6 +1615,7 @@ def main():
         test_dstack_proxy_manager_per_project()
         test_auth()
         test_version()
+        test_boot_refuses_without_commit()
         test_deploy_static()
         test_caps_require_attested()
         test_operator_debug()


### PR DESCRIPTION
## What it does
Makes a daemon without a truthful version identity impossible to miss: the Dockerfile **fails the build** when `GIT_COMMIT` is not passed, and the daemon **refuses to boot** when `DAEMON_COMMIT` is empty and no `.git` is present. `docker-compose.yaml` now passes the commit through `build.args`, so `docker compose build` works without `ship-fix.sh`. The request-time `git rev-parse` fallback in `/_api/version` is gone — identity is settled at boot or the process is already dead.

## What you get by merging
No more silent `DAEMON_COMMIT=""` images (the root cause of the `/_api/version` 500s on webhost-staging). Every build path — compose, ad-hoc `docker build`, CI — fails loudly at build time; a stale/misbuilt image dies at container start with a one-line reason instead of lying on the Tier-1 evidence endpoint hours later.

## Story
Closes #106 (acceptance a + b fully; c partially — see Verification). Restated acceptance: (a) compose passes `GIT_COMMIT` at build; (b) daemon refuses to start on empty `DAEMON_COMMIT`, local git path only where `.git` exists, absence is a hard error, never a placeholder; (c) fresh staging deploy proves `GET /_api/version` == deployed source commit.

## Evidence (Tier 1 — backend/API change)
Full transcript committed at `.evidence/issue-106/transcript.md`. Highlights:

- `docker compose build` **without** `GIT_COMMIT` → build fails: `ERROR: GIT_COMMIT build arg is empty — bake the commit being built...` (exit 1). Plain `docker build` without `--build-arg` fails identically — the guard lives in the Dockerfile, so the ad-hoc-script class that burned staging is covered permanently.
- Compose-built image run locally, real HTTP: `curl http://localhost:18081/_api/version` → `{"version": "dev", "commit": "f3867048"}` — exactly the `GIT_COMMIT` passed to compose build.
- Same image with `DAEMON_COMMIT=` env-blanked → container exits at boot: `RuntimeError: DAEMON_COMMIT is empty and no .git is present: ... Refusing to start rather than report an unknown commit on /_api/version (issue #106).`
- `test_daemon.py`: **ALL TESTS PASSED**, including two new assertions — `/_api/version`'s commit is pinned equal to `git rev-parse --short HEAD` of the running tree, and the no-commit-no-`.git` boot refusal.

## What I could NOT verify (operator-run, credentials missing on zed)
The rubric's deployed-commit pin. The stored ghcr token is **read-only** (`denied: permission_denied: The token provided does not match expected scopes`) and the phala API key returns 401, so build→push→`phala deploy`→pin could not run from this box. Per the scope-down rule this ships as the verifiable subset. To finish acceptance (c):
1. `docker build --build-arg GIT_COMMIT=$(git rev-parse --short HEAD) -t ghcr.io/amiller/tee-socket-proxy:staging-$(git rev-parse --short HEAD) . && docker push ...` (or `GIT_COMMIT=... docker compose build` — that IS acceptance (a) exercised)
2. **Remove the hand-maintained `DAEMON_COMMIT=39c54cc8` literal** from the staging compose `environment:` before deploying — env beats the baked value and would mask the new commit
3. `phala deploy --cvm-id webhost-staging ...` then `curl /_api/version` → 200 with commit == the pushed tree's commit.

## Risk / what to watch
- Anyone with a build habit of bare `docker build .` will now get a hard error — that is intentional; the message says exactly what to pass.
- Local `docker compose up` now wants `GIT_COMMIT=$(git rev-parse --short HEAD)` exported (documented in the compose header).
- Until the operator redeploys, staging keeps serving the mitigation literal `39c54cc8` — unchanged by this PR.
- `deploy-prod7-daemon.sh` / `deploy-webhost-staging-cors.sh` / `zed-baseline/staging-deploy.sh` from the issue no longer exist anywhere on zed; the surviving ad-hoc path (`~/paseo-batch/staging-deploy.sh`) was fixed on the box to pass `--build-arg GIT_COMMIT`. Any future script that forgets the arg is caught by the Dockerfile guard regardless.

<details>
<summary>Diff stats</summary>

```
 Dockerfile          |  3 +++
 PLAN.md             | 30 ++++++++++++++++--------------
 docker-compose.yaml |  9 ++++++--
 proxy/ingress.py    | 18 ++++++++----------
 proxy/main.py       | 29 +++++++++++++++++++++++++++++
 test_daemon.py      | 25 ++++++++++++++++++++++++++
 .evidence/issue-106/transcript.md | new
 7 files changed, 165 insertions(+), 27 deletions(-)
```
</details>