### PR TITLE
RFC-0027 Phase 1: hardware-rooted per-app binding quote

### DIFF
--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -12,11 +12,14 @@ import tarfile
 import time
 from datetime import datetime, timezone
 
+import aiohttp
+
 from .docker_client import DockerClient
 from .projects import Project, ProjectStore, ListenConfig
 from .tracker import ContainerTracker
 from .audit import AuditLog, AuditEntry
 from .runtimes import RuntimeManager, RUNTIME_CONFIG, VOLUME_NAME, VOLUME_MOUNT
+from . import secp, evidence
 
 log = logging.getLogger(__name__)
 
@@ -350,8 +353,67 @@ async def teardown(store: ProjectStore, docker: DockerClient, audit_manager,
     log.info("Torn down %s", name)
 
 
+async def _dstack_post(sock: str, method: str, body: dict) -> dict:
+    conn = aiohttp.UnixConnector(path=sock)
+    async with aiohttp.ClientSession(connector=conn) as session:
+        async with session.post(f"http://localhost/{method}", json=body) as resp:
+            data = await resp.json()
+            if resp.status != 200:
+                raise RuntimeError(f"dstack {method} failed ({resp.status}): {data}")
+            return data
+
+
+async def build_app_binding(sock: str, name: str, tree_hash: str,
+                            commit_sha: str, image_digest: str) -> dict:
+    """RFC 0027 (b): produce a hardware-rooted per-app binding at promote time.
+
+    Derives app_pubkey (GetKey), binds it plus the exact tree_hash into a fresh
+    TDX quote's report_data (GetQuote), and lands the promotion in RTMR3's measured
+    log (EmitEvent). Any RPC failure propagates — a swallowed error here would be a
+    silent false "verified".
+    """
+    app_id = os.environ.get("WEBHOST_APP_ID", "")
+    if not app_id:
+        raise RuntimeError("WEBHOST_APP_ID unset; cannot build RFC 0027 app binding")
+
+    key_path = f"/tee-daemon/projects/{name}"
+    getkey = await _dstack_post(sock, "GetKey", {"path": key_path})
+    if "key" not in getkey:
+        raise RuntimeError(f"GetKey returned no key for {key_path}")
+    # Derive the compressed pubkey; never persist the private key.
+    app_pubkey = secp.compressed_pubkey(bytes.fromhex(getkey["key"].replace("0x", ""))[:32]).hex()
+
+    report_data = evidence.compute_app_report_data(app_id, name, tree_hash, app_pubkey).hex()
+    binding_quote = await _dstack_post(sock, "GetQuote", {"report_data": report_data})
+
+    payload = json.dumps({"name": name, "tree_hash": tree_hash,
+                          "commit": commit_sha, "image_digest": image_digest},
+                         sort_keys=True).encode()
+    await _dstack_post(sock, "EmitEvent",
+                       {"event": "tee-daemon/promote", "payload": payload.hex()})
+
+    return {
+        "kind": "report-data-quote",
+        "binding_quote": binding_quote,
+        "report_data": "0x" + report_data,
+        "preimage": {
+            "domain": evidence.APP_ATTEST_DOMAIN.decode(),
+            "app_id": app_id,
+            "name": name,
+            "tree_hash": tree_hash,
+            "app_pubkey": app_pubkey,
+        },
+        "app_pubkey": app_pubkey,
+        "promote_event": {
+            "rtmr": 3,
+            "event": "tee-daemon/promote",
+            "digest": hashlib.sha384(payload).hexdigest(),
+        },
+    }
+
+
 async def promote(store: ProjectStore, audit_manager, rtm: RuntimeManager,
-                  name: str) -> Project:
+                  name: str, dstack_sock: str | None = None) -> Project:
     """Promote a project from dev mode to attested mode."""
     project = store.load(name)
 
@@ -361,6 +423,14 @@ async def promote(store: ProjectStore, audit_manager, rtm: RuntimeManager,
     # Change mode to attested and save
     project.mode = "attested"
     store.save(project)
+
+    # RFC 0027 (b): hardware-rooted per-app binding quote. Only when dstack is
+    # present (inside the CVM); outside a TEE there is no quote to produce — the
+    # same condition the verification/attest endpoints already gate on.
+    if dstack_sock:
+        project.binding = await build_app_binding(
+            dstack_sock, name, project.tree_hash, project.commit_sha, project.image_digest)
+        store.save(project)
 
     # Record promotion in audit log with source hash (now attested)
     audit = audit_manager.get_audit_log(name)

--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -363,6 +363,14 @@ async def _dstack_post(sock: str, method: str, body: dict) -> dict:
             return data
 
 
+def _app_id_from_eventlog(event_log: str) -> str:
+    """The CVM's app-id, as measured into RTMR3 (event 'app-id', imr 3)."""
+    for e in json.loads(event_log or "[]"):
+        if e.get("imr") == 3 and e.get("event") == "app-id":
+            return e.get("event_payload", "")
+    return ""
+
+
 async def build_app_binding(sock: str, name: str, tree_hash: str,
                             commit_sha: str, image_digest: str) -> dict:
     """RFC 0027 (b): produce a hardware-rooted per-app binding at promote time.
@@ -372,9 +380,12 @@ async def build_app_binding(sock: str, name: str, tree_hash: str,
     log (EmitEvent). Any RPC failure propagates — a swallowed error here would be a
     silent false "verified".
     """
-    app_id = os.environ.get("WEBHOST_APP_ID", "")
+    # app_id is the CVM's own measured identity — read it from the quote event log,
+    # not the WEBHOST_APP_ID env (which is unreliable; empty on staging).
+    probe = await _dstack_post(sock, "GetQuote", {"report_data": "00" * 64})
+    app_id = _app_id_from_eventlog(probe.get("event_log", ""))
     if not app_id:
-        raise RuntimeError("WEBHOST_APP_ID unset; cannot build RFC 0027 app binding")
+        raise RuntimeError("no app-id in the dstack quote event log; cannot build RFC 0027 binding")
 
     key_path = f"/tee-daemon/projects/{name}"
     getkey = await _dstack_post(sock, "GetKey", {"path": key_path})

--- a/proxy/evidence.py
+++ b/proxy/evidence.py
@@ -19,6 +19,11 @@ log = logging.getLogger(__name__)
 # Current schema version - increment when structure changes
 SCHEMA_VERSION = "1.0.0"
 
+# RFC 0027: domain separator for the per-app binding report_data preimage.
+APP_ATTEST_DOMAIN = b"tee-daemon/app-attest/v1"
+# Byte offset of the 64-byte report_data field within a TDX v4 quote (TD report body).
+REPORT_DATA_OFFSET = 568
+
 
 @dataclass
 class OnchainInfo:
@@ -54,7 +59,8 @@ class AppInfo:
     project: str = ""
     source: SourceInfo = field(default_factory=SourceInfo)
     image_digest: str = ""
-    binding_quote: dict = field(default_factory=dict)  # Daemon's promotion quote binding tree_hash
+    binding_quote: dict = field(default_factory=dict)  # KMS GetKey result (signature_chain rooting app_pubkey)
+    binding: dict = field(default_factory=dict)  # RFC 0027 report-data-quote binding block
 
 
 @dataclass
@@ -74,6 +80,7 @@ class EvidenceBundle:
     schema_version: str = SCHEMA_VERSION
     platform_quote: dict = field(default_factory=dict)
     webhost_app_id: str = ""
+    attestation_kind: str = ""  # RFC 0027: "daemon-vouched" | "app-cvm" ("" = no per-app binding)
     onchain: OnchainInfo = field(default_factory=OnchainInfo)
     gateway: GatewayInfo = field(default_factory=GatewayInfo)
     app: AppInfo = field(default_factory=AppInfo)
@@ -84,6 +91,7 @@ class EvidenceBundle:
             "schema_version": self.schema_version,
             "platform_quote": self.platform_quote,
             "webhost_app_id": self.webhost_app_id,
+            "attestation_kind": self.attestation_kind,
             "onchain": asdict(self.onchain),
             "gateway": asdict(self.gateway),
             "app": {
@@ -114,6 +122,8 @@ class VerificationFacts:
     quote_valid: bool = False
     kms_root: bool = False
     webhost_app_id: str = ""
+    attestation_kind: str = ""  # RFC 0027 fact: which identity the binding quote measures
+    binding_verified: bool = False  # RFC 0027: recomputed report_data == quote's report_data
     onchain_approved: bool = False
     gateway_attested: bool = False
     source: SourceInfo = field(default_factory=SourceInfo)
@@ -125,6 +135,8 @@ class VerificationFacts:
             "quote_valid": self.quote_valid,
             "kms_root": self.kms_root,
             "webhost_app_id": self.webhost_app_id,
+            "attestation_kind": self.attestation_kind,
+            "binding_verified": self.binding_verified,
             "onchain_approved": self.onchain_approved,
             "gateway_attested": self.gateway_attested,
             "source": asdict(self.source),
@@ -154,6 +166,7 @@ async def fetch_bundle(endpoint: str, name: str, session: aiohttp.ClientSession)
                 schema_version=data.get("schema_version", SCHEMA_VERSION),
                 platform_quote=data.get("platform_quote", {}),
                 webhost_app_id=data.get("webhost_app_id", ""),
+                attestation_kind=data.get("attestation_kind", ""),
                 onchain=OnchainInfo(**data.get("onchain", {})),
                 gateway=GatewayInfo(**data.get("gateway", {})),
                 app=AppInfo(
@@ -161,6 +174,7 @@ async def fetch_bundle(endpoint: str, name: str, session: aiohttp.ClientSession)
                     source=SourceInfo(**data.get("app", {}).get("source", {})),
                     image_digest=data.get("app", {}).get("image_digest", ""),
                     binding_quote=data.get("app", {}).get("binding_quote", {}),
+                    binding=data.get("app", {}).get("binding", {}),
                 ),
             )
     except Exception as e:
@@ -216,6 +230,32 @@ async def verify(endpoint: str, name: str, opts: dict | None = None) -> Verifica
         # webhost_app_id
         facts.webhost_app_id = bundle.webhost_app_id
 
+        # RFC 0027: per-app binding. attestation_kind names which identity the
+        # binding quote measures; binding_verified recomputes report_data from the
+        # served preimage and checks it against report_data read out of the raw
+        # signed quote bytes — the daemon cannot forge that, which is the point.
+        facts.attestation_kind = bundle.attestation_kind
+        binding = bundle.app.binding
+        if bundle.attestation_kind and binding:
+            pre = binding.get("preimage", {})
+            recomputed = compute_app_report_data(
+                pre.get("app_id", ""), pre.get("name", ""),
+                pre.get("tree_hash", ""), pre.get("app_pubkey", "")).hex()
+            quote_hex = _norm_hex(binding.get("binding_quote", {}).get("quote", ""))
+            if not quote_hex:
+                facts.errors.append("RFC 0027 binding: no raw binding quote to read report_data from")
+            else:
+                # report_data is the 64-byte tail of the TD report body (offset 568).
+                quote_rd = quote_hex[REPORT_DATA_OFFSET * 2:(REPORT_DATA_OFFSET + 64) * 2]
+                facts.binding_verified = quote_rd == recomputed
+                if not facts.binding_verified:
+                    facts.errors.append(
+                        "RFC 0027 binding mismatch: recomputed report_data != the quote's report_data")
+            # DCAP/QVL (that the quote is genuine, current-TCB Intel TDX) is the
+            # consumer's step, as for platform_quote — the field read above needs no key.
+        elif bundle.attestation_kind:
+            facts.errors.append("attestation_kind set but app.binding block missing")
+
         # onchain_approved: true only if chain_id > 0 and DstackApp allowlisted
         # For MVP, chain_id 0 is expected for non-anchored deployments
         if bundle.onchain.chain_id == 0:
@@ -235,51 +275,24 @@ async def verify(endpoint: str, name: str, opts: dict | None = None) -> Verifica
         return facts
 
 
-def compute_report_data_binding(project: str, commit_sha: str, tree_hash: str) -> str:
-    """Compute the report_data that a quote should commit to for tree_hash binding.
+def _norm_hex(s: str) -> str:
+    return s.lower().removeprefix("0x") if isinstance(s, str) else ""
 
-    This binds the project identity to the quote's report_data, so a consumer can
-    verify that the quote actually attests to this specific source tree.
 
-    Format: sha256(project || commit_sha || tree_hash)
+def compute_app_report_data(app_id: str, name: str, tree_hash: str, app_pubkey: str) -> bytes:
+    """RFC 0027 per-app binding report_data (fills the 64-byte quote field exactly).
+
+        SHA-512(DOMAIN ‖ app_id ‖ name ‖ tree_hash ‖ app_pubkey)
+
+    Encoding (unambiguous — `name` is the only variable-length field and is bracketed
+    by fixed-length fields): DOMAIN = raw bytes b"tee-daemon/app-attest/v1"; app_id,
+    tree_hash, app_pubkey are hex-decoded (a leading "0x" is stripped); name is UTF-8.
+    Callers reconstruct this exact preimage from the served `binding.preimage` block.
     """
-    payload = f"{project}|{commit_sha}|{tree_hash}"
-    return hashlib.sha256(payload.encode()).hexdigest()
-
-
-def verify_report_data_binding(quote: dict, project: str, commit_sha: str, tree_hash: str) -> bool:
-    """Verify that the quote's report_data commits to the expected binding.
-
-    Args:
-        quote: Platform quote dict (from GetQuote or GetKey response)
-        project: Project name
-        commit_sha: Git commit SHA
-        tree_hash: Git tree SHA
-
-    Returns:
-        True if report_data matches expected binding
-    """
-    # Get report_data from quote - format varies by dstack version
-    report_data_hex = None
-
-    # Try GetQuote format first
-    if "report_data" in quote:
-        report_data_hex = quote["report_data"]
-    # Try GetKey format (report_data might be in signature_chain)
-    elif "signature_chain" in quote:
-        chain = quote["signature_chain"]
-        if isinstance(chain, dict) and "report_data" in chain:
-            report_data_hex = chain["report_data"]
-        elif isinstance(chain, list) and len(chain) > 0:
-            # Might be nested in chain entries
-            for entry in chain:
-                if isinstance(entry, dict) and "report_data" in entry:
-                    report_data_hex = entry["report_data"]
-                    break
-
-    if not report_data_hex:
-        log.warning("No report_data found in quote")
-        return False
-
-    expected = compute_report_data_binding(project, commit_sha, tree_hash)
-    return report_data_hex == expected
+    h = hashlib.sha512()
+    h.update(APP_ATTEST_DOMAIN)
+    h.update(bytes.fromhex(_norm_hex(app_id)))
+    h.update(name.encode("utf-8"))
+    h.update(bytes.fromhex(_norm_hex(tree_hash)))
+    h.update(bytes.fromhex(_norm_hex(app_pubkey)))
+    return h.digest()

--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -786,7 +786,7 @@ class Ingress:
 
     async def _api_promote(self, name: str) -> web.Response:
         try:
-            project = await promote(self.store, self.audit_manager, self.rtm, name)
+            project = await promote(self.store, self.audit_manager, self.rtm, name, DSTACK_SOCK)
             return web.json_response(asdict(project))
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=400)
@@ -897,7 +897,13 @@ class Ingress:
                 ),
                 image_digest=project.image_digest or "",
                 binding_quote=binding_quote,
+                binding=project.binding or {},
             )
+
+            # RFC 0027: surface the per-app binding kind. Phase 1 produces only
+            # daemon-vouched bindings (report-data-quote on the shared daemon).
+            if project.binding:
+                bundle.attestation_kind = "daemon-vouched"
 
             # Get audit log (retained for backward compatibility, in main bundle for now)
             audit = []

--- a/proxy/projects.py
+++ b/proxy/projects.py
@@ -44,6 +44,7 @@ class Project:
     devices: List[str] = field(default_factory=list)
     egress: bool = False           # route this project's outbound through the shared VPN egress network
     egress_provider: bool = False  # this project PROVIDES the egress (the VPN); joins tee-egress as alias "egress-vpn"
+    binding: dict = field(default_factory=dict)  # RFC 0027 per-app binding block (built at promote)
 
     def __post_init__(self):
         if self.env is None:


### PR DESCRIPTION
Implements **RFC-0027 Recommended Architecture (b), Phase 1** — a hardware-rooted per-app binding quote on the shared daemon. Closes the RFC-0020 layer-3 soft joint: the app↔source binding was the daemon's unmeasured JSON say-so; now `report_data` in a hardware-signed TDX quote carries it, so a compromised daemon can't forge or backdate it. Fixes #112.

### What changed
- **`deploy.py`** — `build_app_binding()` at promote: reads the CVM's own `app_id` from the quote **event log** (not the unreliable `WEBHOST_APP_ID` env), derives `app_pubkey` via `GetKey` (private key never persisted), mints `GetQuote(report_data = SHA-512("tee-daemon/app-attest/v1" ‖ app_id ‖ name ‖ tree_hash ‖ app_pubkey))`, and `EmitEvent("tee-daemon/promote", …)` into RTMR3.
- **`evidence.py`** — serve `attestation_kind` + the `app.binding` block; `verify()` reads `report_data` out of the **raw quote bytes** (offset 568) and checks it against the recomputed preimage — no served-value fallback. Retired the stale sha256 `compute_report_data_binding` so there's one binding formula.
- **`ingress.py` / `projects.py`** — plumb `DSTACK_SOCK` into promote; persist/serve `Project.binding`.

### Verified — acceptance GREEN against webhost-staging (live CVM)
Deployed to webhost-staging, promoted `rfc0027-probe`, ran the RFC-0027 §Phasing Phase-1 criteria against the staging URL:

| # | Criterion | Result |
|---|---|---|
| 1 | `attestation_kind: daemon-vouched` + binding served | ✓ |
| 2 | `report_data` @ offset 568 of the signed quote == SHA-512 preimage | ✓ MATCH |
| 2b | `preimage.app_id` == quote's own event-log app-id | ✓ |
| 3 | `tee-daemon/promote` in fresh platform_quote, RTMR3 replays | ✓ |
| 4 | tamper `tree_hash` → recompute ≠ quote report_data | ✓ caught |

Regression: `test_daemon.py` ALL PASS (Python 3.11.15), incl. the RFC-0020 bundle-schema test.

### Deferred (out of scope for Phase 1)
- **app-cvm** kind (RFC-0027 Phase 2 / RFC-0019) — needs per-app CVM provisioning + base-prod.
- **RTMR0** reproduction needs dstack's acpi-tables build; unrelated to this change.
- Consumer-side: edge-tee `attest.py verify-quote` will DCAP-verify the binding quote + surface `attestation_kind` (separate repo, follow-up).
- `daemon-vouched` is **not isolation** — shared runtime unchanged (RFC-0027 §Open Questions).
