### PR TITLE
runsc-hostnet runtime + /_api/substrate reports Docker's real runtimes (#116)

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -133,7 +133,7 @@ Public (no auth required), only for **attested** projects:
 | | |
 |---|---|
 | `GET /` | Listing of attested projects. `Accept: text/html` returns the daemon's viewer page; `Accept: application/json` returns JSON. |
-| `GET /_api/substrate` | The substrate's runtime configuration: effective OCI runtime (e.g. `sysbox-runc`), supported isolation modes, deno entry-shim hash. Lets a relying party verify what's mediating tenant syscalls. |
+| `GET /_api/substrate` | The substrate's runtime configuration: effective OCI runtime (e.g. `sysbox-runc`), the runtimes Docker actually has (live `GET /info`), network-isolation posture (`host`/`sandbox`/`netns`), supported isolation modes, deno entry-shim hash. Lets a relying party verify what's mediating tenant syscalls — and see a configured/available mismatch rather than trust a name. |
 | `GET /_api/projects/<name>` | Project manifest. |
 | `GET /_api/projects/<name>/audit` | Audit log. |
 | `GET /_api/attest/<name>` | Raw dstack quote. |

--- a/examples/runsc-prelaunch/README.md
+++ b/examples/runsc-prelaunch/README.md
@@ -62,10 +62,17 @@ services:
       # ... other config
 ```
 
-`/_api/substrate` will then report `"effective_runtime": "runsc"`. Tenants run
+`/_api/substrate` will then report `"effective_runtime": "runsc"` (and
+`"network_isolation": "sandbox"`). Tenants run
 under gVisor; the [isolation-probe](https://github.com/amiller/dstack-webhost/tree/main/apps/isolation-probe)
 will show a different signature in `/proc/self/uid_map` and `user_ns` than
 sysbox-runc — gVisor synthesises those from its own Sentry process.
+
+For tenants that need outbound DNS, use `runsc-hostnet` instead (same runsc
+binary, registered with `--network=host`): Docker's embedded resolver at
+`127.0.0.11` is unreachable under plain runsc's netstack, and `HostConfig.Dns`
+does not fix that. `/_api/substrate` reports the difference as
+`"network_isolation": "host"`.
 
 ## Caveats
 

--- a/examples/runsc-prelaunch/prelaunch.sh
+++ b/examples/runsc-prelaunch/prelaunch.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
-# dstack prelaunch script: install gVisor's runsc and register it as a Docker
-# runtime. Installs to /dstack/persistent/bin (writable ZFS); the dstack rootfs
+# dstack prelaunch script: install gVisor's runsc and register it as two
+# Docker runtimes — `runsc` and `runsc-hostnet` (--network=host). The hostnet
+# variant keeps Sentry mediating every other syscall while letting tenant
+# network syscalls reach the container's netns, so Docker's embedded DNS at
+# 127.0.0.11 and container-name discovery work (dead under plain runsc's own
+# netstack). Installs to /dstack/persistent/bin (writable ZFS); the dstack rootfs
 # is read-only, and sha512sum is not present in the prelaunch environment, so
 # verify with whichever sha512 tool is available.
 #
@@ -51,14 +55,18 @@ chmod +x "$INSTALL_DIR/runsc"
 echo "[prelaunch] registering runtime in /etc/docker/daemon.json"
 mkdir -p /etc/docker
 if [ -f /etc/docker/daemon.json ] && command -v jq >/dev/null 2>&1; then
-  jq --arg p "$INSTALL_DIR/runsc" '.runtimes.runsc = {"path": $p}' \
+  jq --arg p "$INSTALL_DIR/runsc" \
+    '.runtimes.runsc = {"path": $p}
+     | .runtimes["runsc-hostnet"] = {"path": $p, "runtimeArgs": ["--network=host"]}' \
     /etc/docker/daemon.json > /etc/docker/daemon.json.new \
     && mv /etc/docker/daemon.json.new /etc/docker/daemon.json
 else
   cat > /etc/docker/daemon.json <<JSON
 {
   "runtimes": {
-    "runsc": { "path": "$INSTALL_DIR/runsc" }
+    "runsc": {"path": "$INSTALL_DIR/runsc"},
+    "runsc-hostnet": {"path": "$INSTALL_DIR/runsc",
+                      "runtimeArgs": ["--network=host"]}
   }
 }
 JSON

--- a/isolation-probe.md
+++ b/isolation-probe.md
@@ -165,10 +165,14 @@ When a tenant runs under plain `runsc`, outbound DNS resolution hits a real inte
 
 `HostConfig.Dns` (the compose `dns:` field) does not fix this — it only changes the upstream resolvers Docker's embedded DNS forwards to, not the embedded DNS address Docker writes into `/etc/resolv.conf`.
 
-The substrate now handles this two ways, so no tenant has to choose between gVisor and DNS:
+The substrate's answer is a second runtime, so no tenant has to choose between gVisor and DNS:
 
 - **`runsc-hostnet`** — the [prelaunch](https://github.com/amiller/dstack-webhost/tree/main/examples/runsc-prelaunch) registers a second runtime, `runsc --network=host`. Network syscalls pass through to the container's own netns, so `127.0.0.11`, embedded DNS and container-name discovery behave exactly as under runc, while Sentry still mediates every other syscall. The trade is explicit, not hidden: netstack isolation is given up — network syscalls reach the host kernel again. `/_api/substrate` reports this as `"network_isolation": "host"` (vs `"sandbox"` for plain runsc, `"netns"` for runc-family).
-- **Plain `runsc` tenants get explicit `HostConfig.Dns`** (routable resolvers — the queried hostname is already disclosed by SNI; see `docker_client.py`).
+
+Plain `runsc` is unchanged: name resolution on a per-project bridge is still broken. `docker_client.py`
+sets an explicit `HostConfig.Dns` for runsc tenants (#108), but that only changes what the embedded
+resolver forwards to — on a user-defined network Docker still writes `127.0.0.11`, so it buys nothing
+there. A tenant that needs netstack isolation *and* DNS has no answer in this substrate today.
 
 `/_api/substrate` reports `available_runtimes` read live from Docker's `GET /info`, and the daemon refuses to start when `DAEMON_CONTAINER_RUNTIME` names a runtime Docker does not have — the substrate's runtime claim cannot silently drift from what the host actually runs.
 

--- a/isolation-probe.md
+++ b/isolation-probe.md
@@ -159,18 +159,18 @@ The takeaway is the same in all cases: the leak is in code that looks correct to
 
 A follow-up demo with one of the above (probably textbook RSA — Hamming-weight recovery is the cleanest concrete signal to land in a docs page) is on the list. The current vault is the warmup that establishes the class.
 
-## Known limitation: gVisor + Docker embedded DNS
+## gVisor + Docker embedded DNS
 
-When the substrate runs under `runsc`, tenants that need outbound DNS resolution can hit a real interaction bug between gVisor's sandbox network stack and Docker's embedded DNS resolver at `127.0.0.11`. Docker forces `nameserver 127.0.0.11` into `/etc/resolv.conf` for any container on a user-defined bridge network (which is most of them, including the per-project `tee-proj-<name>-<mode>` networks the substrate creates). gVisor's own netstack doesn't route to that address. Result: DNS lookups return "Connection refused" even though the host's actual resolver is reachable.
+When a tenant runs under plain `runsc`, outbound DNS resolution hits a real interaction bug between gVisor's sandbox netstack and Docker's embedded DNS resolver at `127.0.0.11`. Docker forces `nameserver 127.0.0.11` into `/etc/resolv.conf` for any container on a user-defined bridge network (which is most of them, including the per-project `tee-proj-<name>-<mode>` networks the substrate creates). gVisor's own netstack doesn't route to that address. Result: DNS lookups return "Connection refused" even though the host's actual resolver is reachable.
 
-`HostConfig.Dns` (the compose `dns:` field) does not fix this — it only changes the upstream resolvers Docker's embedded DNS forwards to, not the embedded DNS address Docker writes into `/etc/resolv.conf`. Workarounds for affected tenants:
+`HostConfig.Dns` (the compose `dns:` field) does not fix this — it only changes the upstream resolvers Docker's embedded DNS forwards to, not the embedded DNS address Docker writes into `/etc/resolv.conf`.
 
-- Bake static IPs or known hosts into the application image instead of relying on DNS.
-- Use the application's own DNS-over-HTTPS resolver (bypasses the OS resolver entirely).
-- Run the tenant as `runtime: runc` (loses gVisor's protection but DNS works).
-- Pull the tenant out of the user-defined bridge entirely — daemon-side substrate change, not yet implemented.
+The substrate now handles this two ways, so no tenant has to choose between gVisor and DNS:
 
-This affected hermes during the live runsc migration on hermes-staging; hermes is currently kept on `runc` for that reason. The isolation-probe doesn't make outbound network calls so it's not affected.
+- **`runsc-hostnet`** — the [prelaunch](https://github.com/amiller/dstack-webhost/tree/main/examples/runsc-prelaunch) registers a second runtime, `runsc --network=host`. Network syscalls pass through to the container's own netns, so `127.0.0.11`, embedded DNS and container-name discovery behave exactly as under runc, while Sentry still mediates every other syscall. The trade is explicit, not hidden: netstack isolation is given up — network syscalls reach the host kernel again. `/_api/substrate` reports this as `"network_isolation": "host"` (vs `"sandbox"` for plain runsc, `"netns"` for runc-family).
+- **Plain `runsc` tenants get explicit `HostConfig.Dns`** (routable resolvers — the queried hostname is already disclosed by SNI; see `docker_client.py`).
+
+`/_api/substrate` reports `available_runtimes` read live from Docker's `GET /info`, and the daemon refuses to start when `DAEMON_CONTAINER_RUNTIME` names a runtime Docker does not have — the substrate's runtime claim cannot silently drift from what the host actually runs.
 
 ## Open attack surface
 

--- a/proxy/docker_client.py
+++ b/proxy/docker_client.py
@@ -80,6 +80,12 @@ class DockerClient:
     async def remove(self, cid: str, force: bool = True):
         await self._raw_request("DELETE", f"/containers/{cid}?force={'true' if force else 'false'}")
 
+    async def info(self) -> dict:
+        status, data = await self._json_request("GET", "/info")
+        if status >= 400:
+            raise RuntimeError(f"info failed ({status}): {data}")
+        return data
+
     async def inspect(self, cid: str) -> dict:
         status, data = await self._json_request("GET", f"/containers/{cid}/json")
         if status >= 400:

--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -70,6 +70,19 @@ MIME_TYPES = {
 }
 
 
+def _network_isolation(runtime: str, available: dict) -> str:
+    """How tenant network syscalls are mediated: "host" (passthrough to the
+    container netns/host kernel stack), "sandbox" (gVisor netstack), "netns"
+    (kernel netns + Docker bridge, runc-family). Derived from Docker's own
+    runtime registration — a name like runsc-hostnet doesn't say it alone."""
+    entry = available.get(runtime) or {}
+    if any(a.startswith("--network=host") for a in entry.get("runtimeArgs") or []):
+        return "host"
+    if runtime.startswith("runsc"):
+        return "sandbox"
+    return "netns"
+
+
 class Ingress:
     def __init__(self, store: ProjectStore, docker: DockerClient,
                  audit_manager: AuditLogManager, tracker: ContainerTracker,
@@ -512,13 +525,16 @@ class Ingress:
             return web.json_response({"error": "invalid token or scope"}, status=403)
         return None
 
-    def _substrate_info(self) -> dict:
+    async def _substrate_info(self) -> dict:
         rt = runtimes_mod.CONTAINER_RUNTIME
+        available = (await self.docker.info()).get("Runtimes") or {}
         shim_sha = hashlib.sha256(
             runtimes_mod._ENTRY_SHIM_DENO.encode()).hexdigest()
         return {
             "container_runtime": rt,
             "effective_runtime": rt or "runc",
+            "available_runtimes": sorted(available),
+            "network_isolation": _network_isolation(rt or "runc", available),
             "isolation_modes": ["shared", "container"],
             "deno_entry_shim_sha256": shim_sha,
             "networks": [runtimes_mod.NETWORK_DEV, runtimes_mod.NETWORK_ATTESTED],
@@ -567,7 +583,7 @@ class Ingress:
             return resp
 
         if method == "GET" and path == "substrate":
-            resp = web.json_response(self._substrate_info())
+            resp = web.json_response(await self._substrate_info())
             resp.headers["Access-Control-Allow-Origin"] = "*"
             return resp
 

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -13,7 +13,7 @@ from .docker_proxy import DockerProxy
 from .dstack_proxy import DstackProxyManager
 from .docker_client import DockerClient
 from .projects import ProjectStore
-from .runtimes import RuntimeManager
+from .runtimes import RuntimeManager, verify_configured_runtime
 from .tunnel import TunnelStore
 from .tokens import TokenStore
 from .broker import BrokerStore, BrokerProxy
@@ -51,6 +51,7 @@ async def start():
     tracker = ContainerTracker()
     audit_manager = AuditLogManager(AUDIT_DIR)
     docker = DockerClient(DOCKER_SOCK)
+    await verify_configured_runtime(docker)
     store = ProjectStore(DATA_DIR)
     rtm = RuntimeManager(docker, store, tracker, audit_manager)
     tunnel_store = TunnelStore(TUNNEL_DIR)

--- a/proxy/runtimes.py
+++ b/proxy/runtimes.py
@@ -121,6 +121,20 @@ def _shared_broker_binds() -> list[str]:
 # Empty string keeps Docker's default (runc).
 CONTAINER_RUNTIME = os.environ.get("DAEMON_CONTAINER_RUNTIME", "")
 
+
+async def verify_configured_runtime(docker: DockerClient):
+    """Refuse to start when DAEMON_CONTAINER_RUNTIME names a runtime Docker
+    does not have — otherwise tenants silently land in a weaker sandbox than
+    /_api/substrate advertises."""
+    rt = CONTAINER_RUNTIME
+    if not rt:
+        return
+    available = (await docker.info()).get("Runtimes") or {}
+    if rt not in available:
+        raise RuntimeError(
+            f"DAEMON_CONTAINER_RUNTIME={rt!r} is not registered with Docker "
+            f"(available: {', '.join(sorted(available))}); refusing to start")
+
 _ENTRY_SHIM_DENO = r"""
 const [ENTRY, FILES, DATA, ENV_JSON] = Deno.args;
 const env = JSON.parse(ENV_JSON || "{}");

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -829,9 +829,19 @@ def test_substrate_endpoint():
     expected = os.environ.get("DAEMON_CONTAINER_RUNTIME", "")
     assert info["container_runtime"] == expected, info
     assert info["effective_runtime"] == (expected or "runc"), info
+    local_runtimes = json.loads(subprocess.run(
+        ["docker", "info", "--format", "{{json .Runtimes}}"],
+        capture_output=True, text=True, check=True).stdout)
+    assert info["available_runtimes"] == sorted(local_runtimes), info
+    assert info["network_isolation"] in ("host", "sandbox", "netns"), info
+    if not expected:
+        assert info["network_isolation"] == "netns", info
     assert "shared" in info["isolation_modes"] and "container" in info["isolation_modes"]
     assert len(info["deno_entry_shim_sha256"]) == 64
-    print(f"  effective_runtime={info['effective_runtime']} shim_sha={info['deno_entry_shim_sha256'][:12]} ✓")
+    print(f"  effective_runtime={info['effective_runtime']} "
+          f"network_isolation={info['network_isolation']} "
+          f"available={','.join(info['available_runtimes'])} "
+          f"shim_sha={info['deno_entry_shim_sha256'][:12]} ✓")
 
 
 def test_per_project_isolation():


### PR DESCRIPTION
## What it does
Registers a second gVisor runtime (`runsc-hostnet` = `runsc --network=host`) in the prelaunch — gVisor with working DNS — and makes `/_api/substrate` report Docker's *actual* runtimes (live `GET /info`) plus an explicit network-isolation posture, instead of echoing an env var as a fact. A daemon configured for a runtime Docker doesn't have now refuses to start.

## What you get by merging
Tenants stop having to choose between gVisor and DNS, and a relying party reading `/_api/substrate` can no longer be told `runsc` on a host where nothing runs under it (the state pod is in today). Configured/available mismatch is either visible in the payload or prevents startup.

## Story
Closes #116. Acceptance: (1) prelaunch registers both runtimes via both branches; (2) `/_api/substrate` reports Docker's real runtimes + explicit network posture; (3) configured-but-missing runtime fails startup loudly; (4) `test_daemon.py` passes.

Note: the `runtimes.py` shared-runtime comment (issue Part 3, first half) was already fixed on staging by #108 — co-trust rationale only, no DNS rationale left to remove. This PR does the remaining Part 3 half (`isolation-probe.md`).

## Evidence (Tier 1, local — staging deploy evidence pending operator ship)
Per the operator's scope note on #116, the staging ship path runs from the laptop. Local evidence:

**Acceptance 3 — startup fails loudly** (`DAEMON_CONTAINER_RUNTIME=runsc`, local docker has only runc):
```
RuntimeError: DAEMON_CONTAINER_RUNTIME='runsc' is not registered with Docker
(available: io.containerd.runc.v2, runc); refusing to start
```

**Acceptance 2 — substrate reports Docker's real runtimes** (live local daemon, the no-runsc negative case):
```json
{"container_runtime": "", "effective_runtime": "runc",
 "available_runtimes": ["io.containerd.runc.v2", "runc"],
 "network_isolation": "netns", "isolation_modes": ["shared", "container"],
 "deno_entry_shim_sha256": "76f995f51b2b…", "networks": ["tee-apps-dev", "tee-apps-attested"]}
```

**Acceptance 4 — full suite green**: `test_daemon.py` exit 0 (log tail in details); the extended substrate test asserts `available_runtimes` equals local `docker info` exactly.

**Acceptance 1**: `bash -n` clean; jq merge verified to write both keys while preserving pre-existing entries (e.g. `sysbox-runc`), heredoc branch writes both.

## Risk / what to watch
- `DAEMON_CONTAINER_RUNTIME` set on a CVM whose Docker lacks that runtime now aborts boot *of the daemon* (intended, acceptance 3) — watch the first staging deploy with the new prelaunch; registration must land before `DAEMON_CONTAINER_RUNTIME=runsc-hostnet` is set in the compose.
- `/_api/substrate` now hits Docker `/info` per request (already allowlisted on the socket proxy); if Docker is down the endpoint 500s instead of lying — intended.
- `runsc-hostnet` trades netstack isolation for working DNS; the trade is surfaced as `network_isolation: "host"`, not hidden.
- Operator ship steps: deploy webhost-staging with the fixed prelaunch, run the issue's `docker run --runtime=runsc-hostnet … nslookup` + control, then pin `/_api/version` from the laptop.

<details>
<summary>Diff stats + test log tail</summary>

```
 9 files changed, 80 insertions(+), 18 deletions(-)
 DEVELOPER_GUIDE.md                    |  2 +-
 examples/runsc-prelaunch/README.md    |  9 ++++++++-
 examples/runsc-prelaunch/prelaunch.sh | 16 ++++++++++++----
 isolation-probe.md                    | 16 +++++++--------
 proxy/docker_client.py                |  6 ++++++
 proxy/ingress.py                      | 20 ++++++++++++++++++--
 proxy/main.py                         |  3 ++-
 proxy/runtimes.py                     | 14 ++++++++++++++
 test_daemon.py                        | 12 +++++++++++-
```

```
--- Test: public /_api/substrate exposes runtime identity ---
  effective_runtime=runc network_isolation=netns available=io.containerd.runc.v2,runc shim_sha=76f995f51b2b ✓
…
=== ALL TESTS PASSED ===
```
Full log: `~/paseo-batch/out/116/test.log` on zed.
</details>