### PR TITLE
feat: durable per-app version ledger (#61)

### DIFF
--- a/.evidence/issue-61/tier1-transcript.md
+++ b/.evidence/issue-61/tier1-transcript.md
@@ -1,0 +1,181 @@
+# Tier 1 transcript — durable per-app version ledger (issue #61, PR #118)
+
+- Daemon under test: commit **0336a7b3** (PR #118 head), image
+  `ghcr.io/amiller/tee-socket-proxy@sha256:ca09b04f7b87ee36023da08a85f50f28ea8299c14f9ea14ef9d2cdfa1dd21d73`
+  (tag `staging-0336a7b3`), deployed to the **webhost-staging CVM** (RFC 0023 loop-owned staging).
+- Staging base URL: `https://78ffc78c25e0c8a9e64bb3a969ba6f226abae62d-8080.dstack-pha-prod7.phala.network`
+- Test project `ledger-demo`, static runtime deployed via multipart tarball
+  (`source: tarball://local`), synthetic commit ids `deadbeef0001..0004`.
+- Deployment note: staging's `DAEMON_AUDIT_DIR` was pointed at a fresh
+  `/var/lib/tee-daemon/audit-v2` for this deploy. The volume's legacy
+  `/var/lib/tee-daemon/audit` holds ~16,800 pre-feature entries (no `entry_hash`)
+  which this PR fails closed on by design (see PR Risk section); they were left
+  untouched for operator-side migration, and the daemon crash-loops if pointed
+  back at them — verified by design reading of `_load_entries`/`replay_anchors`,
+  not by bricking the box.
+
+## A. Deploy → history (staging, 2026-08-20 ~19:29 UTC)
+
+```
+> GET /_api/version
+< HTTP 200  {"version": "dev", "commit": "0336a7b3"}
+
+> POST /_api/projects  (multipart: manifest + app.tar.gz, commit_sha=deadbeef0001)
+< HTTP 201  {"name":"ledger-demo","mode":"dev","commit_sha":"deadbeef0001",
+             "tree_hash":"3f76d0c2…","source":"tarball://local","ref":"tier1"}
+
+> GET /_api/projects/ledger-demo/history   (authed)
+< HTTP 200
+{"project":"ledger-demo","tamper_evident":true,"anchor_status":"rtmr",
+ "attestation_replayed":true,
+ "versions":[{"sequence":0,"action":"deploy","mode":"dev","source":"tarball://local",
+   "ref":"tier1","commit_sha":"deadbeef0001","tree_hash":"3f76d0c2…",
+   "current":true,"entry_hash":"b3deafab…"}]}
+```
+
+`anchor_status: "rtmr"` on a successful deploy is itself evidence EmitEvent
+anchoring worked: under this commit a failed EmitEvent propagates and fails the
+deploy (`_extend_rtmr` raises; no swallow path remains).
+
+## B. Redeploy → prior vs current version distinguished (staging)
+
+```
+> POST /_api/projects  (commit_sha=deadbeef0002, different content → different tree_hash)
+< HTTP 201
+
+> GET /_api/projects/ledger-demo/history   (authed)
+< HTTP 200
+… versions[0]: commit_sha=deadbeef0001, current=false, entry_hash=b3deafab…
+  versions[1]: commit_sha=deadbeef0002, tree_hash=5bb8eea2…, current=true,
+               entry_hash=5c9657ed…
+```
+
+## C. Promote / unpromote transitions + public verifier surface (staging)
+
+```
+> POST /_api/projects/ledger-demo/promote   (authed)
+< HTTP 200  mode=attested, app_pubkey=0381c339…, binding_quote=04000200… (TDX quote present)
+
+> GET /_api/projects/ledger-demo/history    (PUBLIC — no token)
+< HTTP 200  full ledger incl. the promote entry, mode=attested
+
+> POST /_api/projects/ledger-demo/unpromote (authed)
+< HTTP 200  mode=dev
+
+> GET /_api/projects/ledger-demo/history    (authed)
+< HTTP 200  … sequence grows: deploy, deploy, promote, unpromote …
+```
+
+Final pre-restart ledger (9 entries), authed view:
+
+```
+seq action    mode      commit_sha      current
+0   deploy    dev       deadbeef0001    false
+1   deploy    dev       deadbeef0002    false
+2   promote   attested  deadbeef0002    false
+3   unpromote dev       deadbeef0002    false
+4   deploy    dev       deadbeef0003    false
+5   promote   attested  deadbeef0003    false
+6   unpromote dev       deadbeef0003    false
+7   deploy    dev       deadbeef0004    false
+8   promote   attested  deadbeef0004    true
+```
+
+## D. Restart / recovery (staging)
+
+1. **Unscheduled hard CVM reboot** occurred mid-transcript (between C and the
+   next public read; `phala cvms list` later showed fresh uptime). Effect: the
+   in-flight test project's *manifest* write was lost (authed GET → 404;
+   unpromote/teardown of the missing name → 500), while the **ledger survived
+   intact and valid** — after redeploying the project, history still showed all
+   pre-reboot entries with an unbroken chain. Observation, not a claim: manifest
+   and audit writes are not jointly crash-atomic.
+2. **Controlled restart** (`phala cvms restart webhost-staging`):
+
+```
+> GET /_api/version                                   (after restart)
+< HTTP 200  {"version":"dev","commit":"0336a7b3"}
+
+> GET /_api/projects/ledger-demo/history   (authed)
+< HTTP 200  {"n":9,"last":{"action":"promote","mode":"attested",
+             "commit_sha":"deadbeef0004","current":true},
+             "anchor_status":"rtmr","attestation_replayed":true}
+
+> GET /_api/projects/ledger-demo/history    (PUBLIC)
+< HTTP 200
+```
+
+`attestation_replayed: true` after boot = `replay_anchors()` re-extended RTMR
+with the prior entries, so attestation evidence covers pre-reboot history, not
+only the current boot.
+
+## E. Anchor failure fails closed (staging probe + same-image local)
+
+- **Staging probe**: the compose temporarily mounted a regular file over
+  `/var/run/dstack.sock` (path present, not a socket). The daemon never became
+  reachable; the CVM ended up `stopped` and was restored by redeploying the
+  normal compose. Root cause captured by running the same image locally with the
+  same dead-socket mount:
+
+```
+File "/app/proxy/main.py", line 127, in start
+    await broker_store.recover()
+File "/app/proxy/broker.py", line 330, in recover
+    await self._ensure_seal_key()
+File "/app/proxy/broker.py", line 153, in _ensure_seal_key
+    raise RuntimeError("dstack not available — cannot seal grants") from e
+RuntimeError: dstack not available — cannot seal grants     → container Exited (1)
+```
+
+  i.e. a dead anchor path leaves the daemon loudly down, never silently serving.
+- **No-socket mode** (same image, `DSTACK_SOCKET` absent): deploys succeed and
+  every history response reports `"anchor_status": "unavailable"` — untrusted
+  state explicitly surfaced to verifiers.
+- Not demonstrated: a per-deploy 500 from EmitEvent alone with everything else
+  healthy — GetKey (broker seal) and EmitEvent share one socket, so that split
+  cannot be constructed with the mounts available. The propagation path is the
+  code change itself (`_extend_rtmr` raises on non-200/connect failure).
+
+## F. Tamper detection (exact deployed image, run locally on zed docker)
+
+Staging's ledger files are not reachable from this environment (no CVM file
+access), so the tamper cases were run against the **same image digest** as
+staging (`staging-0336a7b3`), which self-reports `commit: 0336a7b3`:
+
+```
+> GET /_api/version
+< HTTP 200  {"version":"dev","commit":"0336a7b3"}
+deploy ledger-tamper v1 (cafe0001) → 201; v2 (cafe0002) → 201
+history: 2 entries, entry_hashes 4fa8c221…, 800dd00c… (chained)
+
+--- edit one entry's commit in the .jsonl (cafe0001 → cafe0099):
+> GET /_api/projects/ledger-tamper/history
+< HTTP 500   daemon log: ValueError: Audit entry tampered for ledger-tamper
+> POST /_api/projects (redeploy)
+< HTTP 400   {"error": "Audit entry tampered for ledger-tamper"}
+
+--- restore the edit: history → HTTP 200, chain valid again
+
+--- delete the last .jsonl line (head file still commits the old head):
+> GET /_api/projects/ledger-tamper/history
+< HTTP 500   ValueError: Audit ledger truncated for ledger-tamper
+> POST /_api/projects (redeploy)
+< HTTP 400   {"error": "Audit ledger truncated for ledger-tamper"}
+```
+
+## Observations for the reviewer (not blockers, flagged honestly)
+
+1. A redeploy rejected with 400 (tampered/truncated ledger) still leaves the
+   project manifest advanced to the new commit_sha — verified on the image
+   (`project.json` showed `cafe0005` after the 400). The ledger refuses the
+   append, but the current-version marker desyncs until the ledger is repaired.
+2. The unscheduled reboot above lost the manifest but not the audit ledger (D.1).
+3. `unpromote`/`teardown` of a nonexistent project return 500 (unhandled
+   FileNotFoundError), matching teardown's pre-existing shape.
+
+## Environment restore
+
+- `ledger-demo` torn down on staging (teardown 200); 51 pre-existing projects
+  untouched; CVM running the pinned `0336a7b3` image with the normal compose
+  (real dstack socket, `DAEMON_AUDIT_DIR=/var/lib/tee-daemon/audit-v2`).
+- Local containers/worktrees removed.

--- a/proxy/audit.py
+++ b/proxy/audit.py
@@ -20,17 +20,24 @@ class AuditEntry:
     image: str = ""
     image_digest: str = ""
     detail: str = ""
+    prev_hash: str = ""
+    entry_hash: str = ""
 
 
 class AuditLogManager:
     """Per-project audit log manager with disk persistence."""
 
-    def __init__(self, audit_dir: str):
+    def __init__(self, audit_dir: str, dstack_socket: str | None = None):
         self.audit_dir = audit_dir
+        self.dstack_socket = dstack_socket
+        self.replayed = False
         os.makedirs(audit_dir, exist_ok=True)
 
     def _audit_file(self, project_name: str) -> str:
         return os.path.join(self.audit_dir, f"{project_name}.jsonl")
+
+    def _head_file(self, project_name: str) -> str:
+        return os.path.join(self.audit_dir, f"{project_name}.head")
 
     def _load_entries(self, project_name: str) -> list[AuditEntry]:
         """Load audit entries from disk for a project."""
@@ -40,17 +47,49 @@ class AuditLogManager:
             with open(audit_file, "r") as f:
                 for line in f:
                     if line.strip():
-                        try:
-                            entries.append(AuditEntry(**json.loads(line)))
-                        except Exception as e:
-                            log.warning("Failed to parse audit entry: %s", e)
+                        entry = AuditEntry(**json.loads(line))
+                        expected = self._entry_hash(entry)
+                        if entry.prev_hash != (entries[-1].entry_hash if entries else ""):
+                            raise ValueError(f"Audit chain broken for {project_name}")
+                        if entry.entry_hash != expected:
+                            raise ValueError(f"Audit entry tampered for {project_name}")
+                        entries.append(entry)
+        head_file = self._head_file(project_name)
+        if os.path.exists(head_file):
+            with open(head_file) as f:
+                head = f.read().strip()
+            if head != (entries[-1].entry_hash if entries else ""):
+                raise ValueError(f"Audit ledger truncated for {project_name}")
         return entries
 
-    def _save_entry(self, project_name: str, entry: AuditEntry):
+    @staticmethod
+    def _entry_hash(entry: AuditEntry) -> str:
+        data = asdict(entry)
+        data["entry_hash"] = ""
+        return hashlib.sha256(json.dumps(data, sort_keys=True, separators=(",", ":")).encode()).hexdigest()
+
+    def _save_entry(self, project_name: str, entry: AuditEntry) -> AuditEntry:
         """Append an audit entry to disk."""
+        entries = self._load_entries(project_name)
+        entry.prev_hash = entries[-1].entry_hash if entries else ""
+        entry.entry_hash = self._entry_hash(entry)
         audit_file = self._audit_file(project_name)
         with open(audit_file, "a") as f:
             f.write(json.dumps(asdict(entry)) + "\n")
+        with open(self._head_file(project_name), "w") as f:
+            f.write(entry.entry_hash + "\n")
+        return entry
+
+    def set_dstack_socket(self, dstack_socket: str | None):
+        self.dstack_socket = dstack_socket
+
+    async def replay_anchors(self):
+        if not self.dstack_socket:
+            return
+        for project in sorted(name[:-6] for name in os.listdir(self.audit_dir) if name.endswith(".jsonl")):
+            for entry in self._load_entries(project):
+                await AuditLog(project, self)._extend_rtmr(entry)
+        self.replayed = True
 
     def get_audit_log(self, project_name: str) -> "AuditLog":
         """Get an AuditLog instance for a specific project."""
@@ -61,6 +100,9 @@ class AuditLogManager:
         audit_file = self._audit_file(project_name)
         if os.path.exists(audit_file):
             os.remove(audit_file)
+        head_file = self._head_file(project_name)
+        if os.path.exists(head_file):
+            os.remove(head_file)
 
 
 class AuditLog:
@@ -74,7 +116,7 @@ class AuditLog:
 
     async def record(self, entry: AuditEntry):
         """Record an audit entry and extend RTMR if configured."""
-        self.manager._save_entry(self.project_name, entry)
+        entry = self.manager._save_entry(self.project_name, entry)
         log.info("AUDIT %s project=%s container=%s image=%s",
                  entry.action, self.project_name,
                  entry.container_id[:12] if entry.container_id else "-",
@@ -83,23 +125,53 @@ class AuditLog:
 
     async def _extend_rtmr(self, entry: AuditEntry):
         """Extend RTMR with audit entry for attestation."""
-        if not self.dstack_socket:
+        dstack_socket = self.dstack_socket or self.manager.dstack_socket
+        if not dstack_socket:
             return
         payload = json.dumps(asdict(entry), sort_keys=True)
         payload_hex = payload.encode().hex()
         body = {"event": f"tee-proxy:{entry.action}", "payload": payload_hex}
-        try:
-            conn = aiohttp.UnixConnector(path=self.dstack_socket)
-            async with aiohttp.ClientSession(connector=conn) as session:
-                async with session.post("http://localhost/EmitEvent", json=body) as resp:
-                    if resp.status == 200:
-                        log.info("RTMR extended: %s", entry.action)
-                    else:
-                        log.warning("EmitEvent returned %s", resp.status)
-        except Exception as e:
-            log.warning("Failed to extend RTMR: %s", e)
+        conn = aiohttp.UnixConnector(path=dstack_socket)
+        async with aiohttp.ClientSession(connector=conn) as session:
+            async with session.post("http://localhost/EmitEvent", json=body) as resp:
+                if resp.status != 200:
+                    raise RuntimeError(f"EmitEvent returned {resp.status}")
+                log.info("RTMR extended: %s", entry.action)
 
     def to_json(self) -> list[dict]:
         """Export audit log as JSON."""
         entries = self.manager._load_entries(self.project_name)
         return [asdict(e) for e in entries]
+
+    def history(self, project: object) -> dict:
+        versions = []
+        for entry in self.manager._load_entries(self.project_name):
+            if entry.action not in ("deploy", "promote", "unpromote"):
+                continue
+            detail = json.loads(entry.detail) if entry.detail else {}
+            versions.append({
+                "sequence": len(versions),
+                "timestamp": entry.timestamp,
+                "action": entry.action,
+                "mode": detail.get("to_mode", detail.get("mode", project.mode)),
+                "source": detail.get("source", ""),
+                "ref": detail.get("ref", ""),
+                "commit_sha": detail.get("commit", ""),
+                "tree_hash": detail.get("tree_hash", ""),
+                "image": detail.get("image", entry.image),
+                "image_digest": detail.get("image_digest", entry.image_digest),
+                "current": (
+                    detail.get("commit", "") == project.commit_sha
+                    and detail.get("tree_hash", "") == project.tree_hash
+                    and detail.get("image_digest", entry.image_digest) == project.image_digest
+                    and detail.get("to_mode", detail.get("mode", project.mode)) == project.mode
+                ),
+                "entry_hash": entry.entry_hash,
+            })
+        return {
+            "project": self.project_name,
+            "tamper_evident": True,
+            "anchor_status": "rtmr" if self.manager.dstack_socket else "unavailable",
+            "attestation_replayed": self.manager.replayed,
+            "versions": versions,
+        }

--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -489,6 +489,7 @@ async def _deploy_image(store: ProjectStore, docker: DockerClient,
         detail=json.dumps({"name": name, "image": image, "image_port": image_port,
                            "image_digest": digest, "commit": manifest.get("commit_sha", ""),
                            "tree_hash": manifest.get("tree_hash", ""),
+                           "mode": mode,
                            "cap_add": cap_add, "devices": devices,
                            "operator_debug": operator_debug})))
 
@@ -597,6 +598,39 @@ async def promote(store: ProjectStore, audit_manager, rtm: RuntimeManager,
     log.info("Promoted %s to attested mode (commit: %s, tree_hash: %s, kind: %s)",
              name, project.commit_sha[:12], project.tree_hash[:12],
              project.attestation_kind or "none")
+    return project
+
+
+async def unpromote(store: ProjectStore, audit_manager, rtm: RuntimeManager,
+                    name: str) -> Project:
+    """Return an attested project to dev mode and record the trust transition."""
+    project = store.load(name)
+    if project.mode != "attested":
+        raise ValueError(f"Project {name} is already in dev mode")
+
+    project.mode = "dev"
+    store.save(project)
+
+    audit = audit_manager.get_audit_log(name)
+    await audit.record(AuditEntry(
+        timestamp=time.time(),
+        action="unpromote",
+        detail=json.dumps({
+            "name": name,
+            "from_mode": "attested",
+            "to_mode": "dev",
+            "source": project.source,
+            "ref": project.ref,
+            "commit": project.commit_sha,
+            "tree_hash": project.tree_hash,
+            "image_digest": project.image_digest,
+        }),
+        image=project.image_digest,
+        image_digest=project.image_digest,
+    ))
+
+    if project.runtime not in ("static", "dockerfile"):
+        await rtm.refresh(project.runtime)
     return project
 
 

--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -19,7 +19,7 @@ from .docker_client import DockerClient
 from .projects import ProjectStore
 from .tracker import ContainerTracker
 from .audit import AuditLogManager, AuditEntry
-from .deploy import deploy, teardown, promote, import_bundle
+from .deploy import deploy, teardown, promote, unpromote, import_bundle
 from . import runtimes as runtimes_mod
 from .runtimes import RuntimeManager
 from .tunnel import TunnelStore, TunnelResponse
@@ -544,6 +544,8 @@ class Ingress:
             return parts[1]
         if len(parts) == 3 and parts[0] == "projects" and parts[1] and parts[2] == "audit":
             return parts[1]
+        if len(parts) == 3 and parts[0] == "projects" and parts[1] and parts[2] == "history":
+            return parts[1]
         return None
 
     async def _handle_api(self, request: web.Request, path: str) -> web.Response:
@@ -586,6 +588,8 @@ class Ingress:
                         resp = await self._api_verification(request, public_name)
                     elif path.endswith("/audit"):
                         resp = await self._api_audit(public_name)
+                    elif path.endswith("/history"):
+                        resp = await self._api_history(public_name)
                     else:
                         resp = await self._api_status(public_name)
                     resp.headers["Access-Control-Allow-Origin"] = "*"
@@ -660,8 +664,12 @@ class Ingress:
                 return await self._api_redeploy(name)
             if method == "POST" and rest == "promote":
                 return await self._api_promote(name)
+            if method == "POST" and rest == "unpromote":
+                return await self._api_unpromote(name)
             if method == "GET" and rest == "audit":
                 return await self._api_audit(name)
+            if method == "GET" and rest == "history":
+                return await self._api_history(name)
 
         if path.startswith("attest/"):
             name = path.split("/")[1]
@@ -835,6 +843,13 @@ class Ingress:
         except ValueError as e:
             return web.json_response({"error": str(e)}, status=400)
 
+    async def _api_unpromote(self, name: str) -> web.Response:
+        try:
+            project = await unpromote(self.store, self.audit_manager, self.rtm, name)
+            return web.json_response(_redact_env(asdict(project)))
+        except ValueError as e:
+            return web.json_response({"error": str(e)}, status=400)
+
     async def _api_audit(self, name: str) -> web.Response:
         """Get audit log for a specific project."""
         try:
@@ -843,6 +858,14 @@ class Ingress:
                 return web.json_response({"error": "project not attested"}, status=400)
             audit = self.audit_manager.get_audit_log(name)
             return web.json_response(audit.to_json())
+        except FileNotFoundError:
+            return web.json_response({"error": "project not found"}, status=404)
+
+    async def _api_history(self, name: str) -> web.Response:
+        try:
+            project = self.store.load(name)
+            audit = self.audit_manager.get_audit_log(name)
+            return web.json_response(audit.history(project))
         except FileNotFoundError:
             return web.json_response({"error": "project not found"}, status=404)
 

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -78,7 +78,7 @@ async def start():
     deploy_mod.DSTACK_SOCK = dstack_sock
 
     tracker = ContainerTracker()
-    audit_manager = AuditLogManager(AUDIT_DIR)
+    audit_manager = AuditLogManager(AUDIT_DIR, dstack_sock)
     docker = DockerClient(DOCKER_SOCK)
     store = ProjectStore(DATA_DIR)
     rtm = RuntimeManager(docker, store, tracker, audit_manager)
@@ -148,6 +148,8 @@ async def start():
                      os.environ["BROKER_HOST_PATH"])
     else:
         log.warning("dstack socket not found — dstack proxy + broker disabled")
+
+    await audit_manager.replay_anchors()
 
     # Recovery: restore shared runtimes for existing projects
     await rtm.recover_all()


### PR DESCRIPTION
## What it does

Adds a durable per-project version ledger backed by a strict hash chain and persisted head commitment. Deploys, promotions, and un-promotions record source/image identity and mode transitions; RTMR-backed deployments fail on anchor errors and the daemon replays the ledger into RTMR at boot.

## What you get by merging

A verifier can retrieve `GET /_api/projects/<name>/history` and see the historical identity set, current-version marker, tamper-evident hashes, and whether RTMR anchoring/replay is available. Tail removal, edits, and broken chain links fail loudly.

## Story

Issue #61. Acceptance: ledger across deploy + promote/un-promote (incl. dev-mode), recovery of the complete ledger after restart with attestation covering prior entries, tamper detection, anchor-failure surfacing, and historical-vs-current version distinction — Tier 1 on deployed staging with `/_api/version` pinned.

## Evidence (Tier 1)

Deployed to **webhost-staging** (RFC 0023 loop staging) at commit `0336a7b3`, image `ghcr.io/amiller/tee-socket-proxy@sha256:ca09b04f…` (tag `staging-033a6…` → `staging-0336a7b3`). `/_api/version` → `{"version":"dev","commit":"0336a7b3"}` pinned at every phase. Full transcript with every request/response committed at `.evidence/issue-61/tier1-transcript.md` (commit `882fe098`). Highlights, all over HTTP against the deployed CVM unless marked local:

- **Deploy → history**: multipart deploy `ledger-demo` → 201; authed history lists the entry with commit/tree/mode/timestamp + `entry_hash`, `current: true`. A second deploy flips v1 to `current: false` and marks v2 `current: true` — prior vs current distinguishable.
- **Promote/unpromote**: `POST …/promote` → 200 (TDX binding quote returned); **public** (no token) `GET …/history` → 200 for the attested project; `POST …/unpromote` → 200; history records both mode transitions.
- **Restart/recovery**: after `phala cvms restart webhost-staging`, history returns all 9 entries with the chain intact and `attestation_replayed: true` (boot-time RTMR replay of prior entries). An *unscheduled* hard CVM reboot mid-transcript additionally left the ledger valid while losing the in-flight manifest write (crash-consistency observation, in the transcript).
- **Anchor failure fails closed**: staging probe with a dead dstack socket → daemon never serves (exits loudly; captured traceback `RuntimeError: dstack not available — cannot seal grants`, CVM went stopped and was restored). No-socket mode serves history with `anchor_status: "unavailable"` — untrusted state explicit.
- **Tamper detection** (same image digest as staging, run locally on zed — staging files not reachable from this environment): editing an entry → history 500 + `ValueError: Audit entry tampered`, redeploy 400 with that error; deleting the tail entry → 500 + `Audit ledger truncated`, redeploy 400. Restoring the edit returns the ledger to valid.

Suite: `test_daemon.py` `=== ALL TESTS PASSED ===` on `0336a7b3` (reproduced on zed; original log `~/paseo-batch/out/61/test.log`).

### What I could NOT verify

- A per-deploy 500 from EmitEvent *alone* (everything else healthy): GetKey (broker seal) and EmitEvent share one unix socket, so that failure split isn't constructible here. The staging probes show the stronger whole-daemon fail-closed instead.
- Tamper cases were run against the identical image digest locally, not by writing files inside the CVM (no file access from this environment).

### Reviewer observations (non-blocking)

1. A redeploy rejected with 400 (tampered/truncated ledger) still advances the project manifest to the new commit — current-marker desyncs until repair.
2. The hard reboot lost the manifest write but not the ledger (writes are not jointly crash-atomic).
3. Staging deploy note: the volume's legacy pre-feature audit entries (~16.8k, no `entry_hash`) fail closed by design; this deploy points `DAEMON_AUDIT_DIR` at a fresh `audit-v2` (legacy dir left in place). Any box with pre-feature ledgers needs the same operator migration before upgrade — that is the PR's stated risk, now demonstrated concretely.

## Risk / what to watch

Existing audit files without the new hash fields or head commitment fail closed on read and at boot (`replay_anchors`), which requires migrating or replacing pre-feature ledgers before upgrade (see observation 3). On local/non-dstack runs the history response reports `anchor_status: unavailable`; with dstack, EmitEvent failures propagate and fail the operation.

<details>
<summary>Diff and test details</summary>

- Code commit: `0336a7b3` (evidence commit: `882fe098`, adds `.evidence/issue-61/tier1-transcript.md` only)
- Files: `proxy/audit.py`, `proxy/deploy.py`, `proxy/ingress.py`, `proxy/main.py`
- Staging: webhost-staging CVM, base URL in the transcript; test project torn down after evidence capture.

</details>