### PR TITLE
runsc: enable broker host Unix sockets

### DIFF
--- a/.evidence/issue-6/probe-server.ts
+++ b/.evidence/issue-6/probe-server.ts
@@ -1,0 +1,47 @@
+// Issue #6 acceptance probe — runs INSIDE the tenant.
+// Performs the broker calls the acceptance names and returns the transcript.
+const SOCK = "/run/broker/dstack.sock";
+
+async function rpc(method: string, body: Record<string, unknown>) {
+  try {
+    const conn = await Deno.connect({ transport: "unix", path: SOCK });
+    const payload = JSON.stringify(body);
+    const req =
+      `POST /${method} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\n` +
+      `Content-Length: ${payload.length}\r\nConnection: close\r\n\r\n${payload}`;
+    await conn.write(new TextEncoder().encode(req));
+    const dec = new TextDecoder();
+    let raw = "";
+    const buf = new Uint8Array(8192);
+    while (true) {
+      const n = await conn.read(buf);
+      if (n === null) break;
+      raw += dec.decode(buf.subarray(0, n));
+      if (raw.length > 262144) break;
+    }
+    conn.close();
+    const idx = raw.indexOf("\r\n\r\n");
+    const status = parseInt(raw.split(" ")[1] || "0", 10);
+    return { status, body: raw.slice(idx + 4) };
+  } catch (e) {
+    return { status: 0, body: "", err: String(e) };
+  }
+}
+
+export default async (_req: Request, _ctx: { env: Record<string, string> }) => {
+  const out = {
+    ts: new Date().toISOString(),
+    sock: SOCK,
+    // The acceptance call, in both dstack-proxy generations:
+    // post-#80 proxies take {"name"} and derive the path; the pre-#80 proxy
+    // takes {"path"} pinned under /tee-daemon/.
+    getkey_name_mode: await rpc("GetKey", { name: "issue6-demo" }),
+    getkey_path_mode: await rpc("GetKey", { path: "/tee-daemon/issue6-demo/data" }),
+    // A non-allowlisted method must be denied BY THE BROKER (403), proving the
+    // tenant is behind the filtered proxy, not a raw dstack socket.
+    denied_method: await rpc("DeriveKey", {}),
+  };
+  return new Response(JSON.stringify(out, null, 2), {
+    headers: { "content-type": "application/json" },
+  });
+};

--- a/.evidence/issue-6/staging-transcript.txt
+++ b/.evidence/issue-6/staging-transcript.txt
@@ -1,0 +1,73 @@
+# Issue #6 acceptance evidence — captured 2026-08-27T22:24:27Z against deployed staging (webhost-staging CVM)
+
+```
+## GET /_api/version (public, RFC-0015)
+HTTP/1.1 200 OK
+Content-Type: application/json; charset=utf-8
+Access-Control-Allow-Origin: *
+Content-Length: 40
+Date: Thu, 27 Aug 2026 22:24:27 GMT
+Server: Python/3.11 aiohttp/3.14.3
+
+{"version": "dev", "commit": "0336a7b3"}```
+
+## GET /issue6-hostuds/ — in-tenant transcript (oci_runtime=runsc-hostuds, mode=attested, isolation=container)
+```
+HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 762
+Date: Thu, 27 Aug 2026 22:24:27 GMT
+Server: Python/3.11 aiohttp/3.14.3
+
+{
+  "ts": "2026-08-27T22:24:27.774Z",
+  "sock": "/run/broker/dstack.sock",
+  "getkey_name_mode": {
+    "status": 200,
+    "body": "{\"key\":\"fa9d4329fda3dd7ac0e40a590040c79a5f8071a52520d767c0e32e9eb34e49ca\",\"signature_chain\":[\"f6b7fe90beda6b41e3481c13353d160f65923d4d882f697399a55e7b5e953feb5f2061c4d911741c5858ea9ead304dfeebe1d431a0d4503e197894aa96377adc01\",\"3eda91c74da5f88885797a23c7fbc13b54700946451ea9af6f5110bcceff943b1e495fef7250250d6af6cd14ba6ab2e43f17eb6009cfbc668716e6feccf2283d01\"]}"
+  },
+  "getkey_path_mode": {
+    "status": 400,
+    "body": "{\"message\": \"GetKey requires a `name` (no '/', '\\\\', '..', or leading '.')\"}"
+  },
+  "denied_method": {
+    "status": 403,
+    "body": "{\"message\": \"Method DeriveKey not permitted\"}"
+  }
+}```
+
+## Contrast (captured 2026-08-27T22:15:11Z, before teardown): identical app under oci_runtime=runsc — no --host-uds
+```
+{
+  "ts": "2026-08-27T22:15:11.647Z",
+  "sock": "/run/broker/dstack.sock",
+  "getkey_name_mode": {
+    "status": 0,
+    "body": "",
+    "err": "ConnectionRefused: Connection refused (os error 111)"
+  },
+  "getkey_path_mode": {
+    "status": 0,
+    "body": "",
+    "err": "ConnectionRefused: Connection refused (os error 111)"
+  },
+  "denied_method": {
+    "status": 0,
+    "body": "",
+    "err": "ConnectionRefused: Connection refused (os error 111)"
+  }
+}
+HTTP 200
+```
+
+## GET /_api/projects/issue6-hostuds/audit (public for attested projects)
+```
+[{"timestamp": 1787868520.3234396, "action": "deploy", "container_id": "", "image": "denoland/deno:latest", "image_digest": "sha256:efd53a4aeff1bbe0f05180c628a02b78661d955f56219e2e932800e8e13e1982", "detail": "{\"name\": \"issue6-hostuds\", \"mode\": \"attested\", \"source\": \"tarball://issue6-probe\", \"ref\": \"pr127\", \"commit\": \"\", \"tree_hash\": \"97816f756f2542bc32588d5d6c10540227d653516aeffad26097d4c77d3a1f01\", \"cap_add\": [], \"devices\": [], \"operator_debug\": false}", "prev_hash": "", "entry_hash": "5000417cfa1fac16da45448591c8a523b7aa0e75556fd1a601a51f552b4f4c88"}]```
+
+## GET /_api/attest/issue6-hostuds — dstack-derived project key (RTMR signature chain)
+```
+{"signature_chain": ["7f2c77ea435dd29fdededd5485ed3690293ceca36e3230ee3e31ab648e6f72c3048ee1df6985e1908effe93508e16dd54c51edd1d76d0d563b413aa7675c5b5300", "3eda91c74da5f88885797a23c7fbc13b54700946451ea9af6f5110bcceff943b1e495fef7250250d6af6cd14ba6ab2e43f17eb6009cfbc668716e6feccf2283d01"], "pubkey": "03b7d626191e2c1ca08f73623fa4b5f01c68571883744d0a22885fb078619161e1"}```
+
+## GET /_api/substrate (public)
+```
+{"container_runtime": "runc", "effective_runtime": "runc", "isolation_modes": ["shared", "container"], "deno_entry_shim_sha256": "76f995f51b2b90adb60efaf12b7a97776513fc341493d75849671bc03cdc54a3", "networks": ["tee-apps-dev", "tee-apps-attested"]}```

--- a/.evidence/issue-6/tier1-transcript.md
+++ b/.evidence/issue-6/tier1-transcript.md
@@ -1,0 +1,64 @@
+# Tier 1 transcript — runsc tenants reach the broker via `runsc-hostuds` (issue #6, PR #127)
+
+- CVM: **webhost-staging** (RFC 0023 autonomous staging), redeployed
+  2026-08-27 with `--pre-launch-script examples/runsc-prelaunch/prelaunch.sh`
+  **from this PR branch** — the deploy that registers `runsc`, `runsc-hostuds`
+  (`--host-uds=open`) and `runsc-hostnet` in the CVM's `/etc/docker/daemon.json`.
+  The CVM rebooted once under load after the demo and came back clean with the
+  runtimes still registered (the pinned-hash boot fix holding).
+- Daemon under test: image `ghcr.io/amiller/tee-socket-proxy@sha256:ca09b04f…`
+  (the compose-pinned staging build, commit **0336a7b3** — staging WITHOUT this
+  PR's 4-file diff; see "What this does NOT pin" below). The staging compose was
+  also corrected to the PR #81 broker contract (`/var/run/tee-broker` host bind +
+  `BROKER_HOST_PATH`) — without it attested apps get no broker mount at all.
+- Staging base: `https://78ffc78c25e0c8a9e64bb3a969ba6f226abae62d-8080.dstack-pha-prod7.phala.network`
+- Probe tenants: two identical Deno apps (`.evidence/issue-6/probe-server.ts`,
+  deployed by multipart tarball, `mode: attested`, `isolation: container`),
+  differing only in `oci_runtime`: `runsc-hostuds` vs plain `runsc`.
+  A successful 201 deploy under `oci_runtime: runsc-hostuds` is itself proof the
+  runtime is registered — Docker rejects creates naming an unknown runtime.
+
+## What the transcript shows (`.evidence/issue-6/staging-transcript.txt`)
+
+1. **The acceptance call completes.** From *inside* the `runsc-hostuds` tenant,
+   `GetKey {"name":"issue6-demo"}` over `/run/broker/dstack.sock` → HTTP 200
+   with a dstack-derived key and signature chain. Same app under plain `runsc`:
+   `ConnectionRefused (os error 111)` on every call — the connect(2) failure
+   (curl exit 7 family) the issue names. The success/failure pair proves both
+   that gVisor is active and that `--host-uds=open` is the load-bearing flag.
+2. **The broker stays in the path.** `DeriveKey` → HTTP 403 "Method DeriveKey
+   not permitted" from *inside the tenant*; legacy `path`-mode GetKey → 400.
+   The tenant's only dstack channel is the filtered per-project socket.
+3. **Audit surface.** `GET /_api/projects/issue6-hostuds/audit` (public,
+   attested) returns the hash-chained deploy entry; `GET /_api/attest/…`
+   returns the RTMR signature chain. Note: per-`GetKey`-call usage lines do not
+   exist in ANY version of the dstack proxy (denials are log.warning'd; allowed
+   calls forward silently) — flagged to the operator in the PR, not papered over.
+
+## Reproduce
+
+```bash
+# probe app + manifests: .evidence/issue-6/probe-server.ts
+curl -X POST "$B/_api/projects" -H "Authorization: Bearer $TOKEN" \
+  -F 'manifest={"name":"issue6-hostuds","runtime":"deno","entry":"server.ts","mode":"attested","isolation":"container","oci_runtime":"runsc-hostuds","listen":{"port":8080},"source":"tarball://issue6-probe","ref":"pr127"};type=application/json' \
+  -F 'files=@app.tar.gz;type=application/gzip'
+curl "$B/issue6-hostuds/"
+```
+
+## What this does NOT pin
+
+`/_api/version` reports `0336a7b3` (the deployed staging build), **not** this
+PR's `f92ac371`: pushing the new image needs a ghcr write credential that is
+operator-only from this box (`docker push` denied; `gh` token lacks
+`write:packages`). The PR's daemon-side delta beyond the deployed build is a
+single line (`runtime.startswith("runsc")` for Docker Dns on runsc variants —
+not exercised by this unix-socket flow; unit-tested in
+`proxy/test_docker_client.py`). The PR's load-bearing change — the
+`runsc-hostuds` registration — IS the deployed, demonstrated part.
+
+## Operational note (watch this)
+
+Two concurrent gVisor tenants plus the pre-existing tenant fleet (24 containers)
+rebooted this tdx.small CVM (1 vCPU / 2 GB) once, ~1 minute after both probes
+were up. It recovered unattended. The contrast probe (`issue6-plain`) was torn
+down after capture; `issue6-hostuds` is left deployed for review.

--- a/examples/runsc-prelaunch/README.md
+++ b/examples/runsc-prelaunch/README.md
@@ -79,6 +79,11 @@ socket or another project's broker. Set:
       - DAEMON_CONTAINER_RUNTIME=runsc-hostuds
 ```
 
+The per-project `oci_runtime: runc` opt-out in a deploy manifest pins one app
+back to runc. It remains available, but it is for **TRUSTED tenants only**: a
+runc app shares the host kernel, so it must be trusted against kernel-CVE-class
+bugs — exactly the exposure the runsc variants exist to remove.
+
 For apps that need outbound DNS, use `runsc-hostnet` instead (same runsc
 binary, registered with `--network=host`): Docker's embedded resolver at
 `127.0.0.11` is unreachable under plain runsc's netstack, and `HostConfig.Dns`

--- a/examples/runsc-prelaunch/README.md
+++ b/examples/runsc-prelaunch/README.md
@@ -1,7 +1,7 @@
 # runsc-prelaunch
 
-A dstack prelaunch script that installs gVisor's `runsc` and registers it as a
-Docker runtime, without modifying the dstack base image. Validates the
+A dstack prelaunch script that installs gVisor's `runsc` and registers it as
+Docker runtimes, without modifying the dstack base image. Validates the
 "gVisor is provisionable on stock dstack today" claim from
 [isolation-probe](../../isolation-probe.md).
 
@@ -67,6 +67,17 @@ services:
 under gVisor; the [isolation-probe](https://github.com/amiller/dstack-webhost/tree/main/apps/isolation-probe)
 will show a different signature in `/proc/self/uid_map` and `user_ns` than
 sysbox-runc — gVisor synthesises those from its own Sentry process.
+
+For apps that need the daemon's broker socket, use `runsc-hostuds` (same runsc
+binary, registered with `--host-uds=open`). It permits gVisor to connect to
+host Unix sockets that the container explicitly mounts, without permitting it
+to create host sockets. The tee-daemon broker volume mounts only the
+project-scoped filtered socket, so the app still cannot reach the raw dstack
+socket or another project's broker. Set:
+
+```yaml
+      - DAEMON_CONTAINER_RUNTIME=runsc-hostuds
+```
 
 For apps that need outbound DNS, use `runsc-hostnet` instead (same runsc
 binary, registered with `--network=host`): Docker's embedded resolver at

--- a/examples/runsc-prelaunch/prelaunch.sh
+++ b/examples/runsc-prelaunch/prelaunch.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
-# dstack prelaunch script: install gVisor's runsc and register it as two
-# Docker runtimes — `runsc` and `runsc-hostnet` (--network=host). The hostnet
+# dstack prelaunch script: install gVisor's runsc and register it as three
+# Docker runtimes — `runsc`, `runsc-hostuds` (--host-uds=open), and
+# `runsc-hostnet` (--network=host). The hostnet
 # variant keeps Sentry mediating every other syscall while letting app
 # network syscalls reach the container's netns, so Docker's embedded DNS at
 # 127.0.0.11 and container-name discovery work (dead under plain runsc's own
@@ -57,6 +58,7 @@ mkdir -p /etc/docker
 if [ -f /etc/docker/daemon.json ] && command -v jq >/dev/null 2>&1; then
   jq --arg p "$INSTALL_DIR/runsc" \
     '.runtimes.runsc = {"path": $p}
+     | .runtimes["runsc-hostuds"] = {"path": $p, "runtimeArgs": ["--host-uds=open"]}
      | .runtimes["runsc-hostnet"] = {"path": $p, "runtimeArgs": ["--network=host"]}' \
     /etc/docker/daemon.json > /etc/docker/daemon.json.new \
     && mv /etc/docker/daemon.json.new /etc/docker/daemon.json
@@ -65,6 +67,8 @@ else
 {
   "runtimes": {
     "runsc": {"path": "$INSTALL_DIR/runsc"},
+    "runsc-hostuds": {"path": "$INSTALL_DIR/runsc",
+                       "runtimeArgs": ["--host-uds=open"]},
     "runsc-hostnet": {"path": "$INSTALL_DIR/runsc",
                       "runtimeArgs": ["--network=host"]}
   }

--- a/proxy/docker_client.py
+++ b/proxy/docker_client.py
@@ -46,7 +46,7 @@ class DockerClient:
         host_config: dict = {"Binds": binds}
         if runtime:
             host_config["Runtime"] = runtime
-        if runtime == "runsc":
+        if runtime.startswith("runsc"):
             host_config["Dns"] = GVISOR_DNS
         if restart_policy:
             host_config["RestartPolicy"] = restart_policy

--- a/proxy/test_docker_client.py
+++ b/proxy/test_docker_client.py
@@ -34,6 +34,14 @@ def test_runsc_create_carries_gvisor_dns():
     assert hc["Dns"] == GVISOR_DNS
 
 
+def test_runsc_variants_carry_gvisor_dns():
+    captured, dc = _capturing_client()
+    _create(dc, "runsc-hostuds")
+    hc = captured["body"]["HostConfig"]
+    assert hc["Runtime"] == "runsc-hostuds"
+    assert hc["Dns"] == GVISOR_DNS
+
+
 def test_runc_and_shared_creates_keep_embedded_dns():
     for runtime in ("runc", ""):
         captured, dc = _capturing_client()


### PR DESCRIPTION
## What it does

Registers a `runsc-hostuds` Docker runtime using gVisor's connect-only `--host-uds=open` flag. Broker-enabled runsc containers also receive the same explicit DNS configuration as other runsc variants. Documents the per-project `oci_runtime: runc` opt-out as TRUSTED-tenants-only (issue #6 acceptance item 3).

## What you get by merging

An app using the per-project broker mount can connect to its filtered broker socket while remaining unable to create host sockets or reach another project's broker directory.

## Story

Closes #6. Acceptance, restated:
- A tenant under runsc, with no `oci_runtime: runc` opt-out, reaches the broker and completes one `GetKey` — **demonstrated** (below).
- The tenant is not handed a raw dstack socket; the filtered broker's allowlist still applies — **demonstrated**; the audit surface is the hash-chained deploy ledger + RTMR chain (per-call usage lines do not exist in any version of the dstack proxy — see "could not verify").
- The per-project runc opt-out remains available and is documented as TRUSTED-tenants-only — **added in this PR** (`examples/runsc-prelaunch/README.md`).

## Evidence (Tier 1) — deployed staging, 2026-08-27

The PR's prelaunch script was deployed to the **webhost-staging CVM** via
`phala deploy --pre-launch-script examples/runsc-prelaunch/prelaunch.sh`
(registering `runsc`, `runsc-hostuds`, `runsc-hostnet`). Two identical attested
Deno probes were deployed by tarball, differing only in `oci_runtime`.
Full transcript: `.evidence/issue-6/staging-transcript.md` + `staging-transcript.txt`; probe app: `probe-server.ts`.

**Inside the `runsc-hostuds` tenant** (`GET /issue6-hostuds/` over the public staging URL):

```
"getkey_name_mode": { "status": 200,
  "body": "{\"key\":\"fa9d4329fda3dd7ac0e40a590040c79a5f8071a52520d767c0e32e9eb34e49ca\",\"signature_chain\":[…]}" }
"getkey_path_mode": { "status": 400, "body": "GetKey requires a `name` …" }
"denied_method":    { "status": 403, "body": "Method DeriveKey not permitted" }
```

**Same app under plain `runsc`** (no `--host-uds`; captured 22:15:11Z, torn down after):

```
"getkey_name_mode": { "status": 0, "err": "ConnectionRefused: Connection refused (os error 111)" }
```

The success/refused pair proves gVisor is active (a runc tenant would connect
either way) and that `--host-uds=open` is what carries the broker socket. The
403 comes from the filtered proxy itself, from inside the tenant. Audit:
`GET /_api/projects/issue6-hostuds/audit` → hash-chained `deploy` entry;
`GET /_api/attest/issue6-hostuds` → RTMR signature chain (both pasted in the
transcript). The CVM later rebooted unattended under the load of 24 tenants +
2 gVisor sentries and recovered with the runtimes still registered.

`/_api/version` on staging: `{"version":"dev","commit":"0336a7b3"}` — the
compose-pinned staging build this PR sits on, **not** `f92ac371`:

## What I could NOT verify — need from operator

- **Version pin to this PR's commit.** Building `staging-f92ac371` locally
  works; `docker push` to `ghcr.io/amiller` is denied (the logged-in identity
  lacks package-write; the `gh` token has no `write:packages`). One
  `docker login ghcr.io` with push rights (or an operator push of the local
  tag) + `ship-fix.sh staging` completes the pin. The daemon-side delta beyond
  the deployed build is one unexercised line (Dns for runsc variants,
  unit-tested); the PR's load-bearing change — the runtime registration — is
  the part deployed and demonstrated above.
- **Per-call broker audit lines.** `DstackProxy` logs denials
  (`log.warning`) but no allowed `GetKey` leaves a line in any code version —
  the issue's "audit log still records the call" has no implementation to
  demonstrate. Flagged rather than papered over; a one-line `log.info` in
  `_forward` (or a creds-style usage log per RFC 0018) is the fix if wanted.
- **`docker inspect`-level proof** (Runtime/Binds of the probe container): the
  CVM's ssh-debug sidecar is 2 months stale and rejects the deploy-notes key
  even after recreation (its image is private, so the cause is not readable
  from here). The 201-create under `runsc-hostuds` plus the contrast pair
  stand in as the runtime proof.

Deploy-side changes made on the box (not in this repo): staging compose moved
to the PR #81 broker contract (`/var/run/tee-broker` host bind +
`BROKER_HOST_PATH`; the old `broker_sock` named volume left attested apps with
NO broker mount), and the stale ssh-debug service was recreated.

## Risk / what to watch

- gVisor tenants are memory-heavy: two concurrent probes + the existing
  24-container fleet rebooted this 1 vCPU / 2 GB CVM once (recovered clean).
  `issue6-hostuds` is left deployed for review; `issue6-plain` was torn down.
- The staging prelaunch script is now live on the CVM and runs at every boot —
  pinned to dated release `20260622` + sha512, so upstream rolls cannot wedge
  boot (the 2026-06-24 lesson).
- Local suite: `=== ALL TESTS PASSED ===` on this branch (docker, zed box).

<details>
<summary>Diff stats and logs</summary>

`6 files changed` (4 original + README doc + `.evidence/issue-6/`)

Local suite: full pass on `staging-6` @ `88873c3d` (the original run at `f92ac371` is logged at `~/paseo-batch/out/6/test.log`).

</details>
