### PR TITLE
rfcs: add 0023 — staging CVM roles (webhost-staging vs hermes-staging) (#59)

### DIFF
--- a/rfcs/0023-staging-cvm-autonomous-dev.md
+++ b/rfcs/0023-staging-cvm-autonomous-dev.md
@@ -1,0 +1,48 @@
+# RFC 0023: Staging CVM Roles — webhost-staging vs hermes-staging
+
+## Summary
+Two dstack CVMs look redundant but are **different layers**. `webhost-staging` is the
+autonomous daemon-image test box where the Paseo loop rebuilds and verifies the tee-daemon
+itself. `hermes-staging` is the load-bearing production/app host for the ~17 non-promoted
+apps. Daemon-image development runs only on webhost-staging, because rebuilding the daemon
+restarts it — on hermes-staging that would take down its live apps.
+
+## webhost-staging — the autonomous daemon-image test CVM
+Where the Paseo loop rebuilds and tests the **tee-daemon itself**: each `staging-NN` branch
+is built, tested and deployed here (`ship-fix.sh staging`). Daemon-code issues depend on
+this box — #57 (RFC 0017 export/import) and #58 (RFC 0026 scoped debug sessions) are daemon
+code, so they build and verify here. webhost-staging is therefore **not** retire-able.
+
+Daemon-image development **cannot** run on hermes-staging: rebuilding the daemon restarts
+it and would take down its ~17 live apps.
+
+## hermes-staging — the app host (misnamed; it is production, not staging)
+Runs the ~17 non-promoted apps (otterscope, listen, router-dashboard, vault, tinycloud, …).
+App-level development can happen here; daemon-image development cannot.
+
+## Ship flow
+Paseo loop → `staging-NN` branch → PR (built and tested on webhost-staging). Promotion to
+production is a **laptop-only gated step**: review and merge the PR to `origin/main`, then
+run `ship-fix.sh prod` — the prod target and `TEE_DAEMON_TOKEN` live only on the laptop.
+
+`ship-fix.sh` keeps the two targets visibly distinct:
+
+| target | CVM | compose | env |
+|---|---|---|---|
+| `staging` | `webhost-staging` | `docker-compose.webhost-staging.yaml` | `.env.webhost-staging` |
+| `prod` | `hermes-staging` | `docker-compose.hermes-prod.yaml` | `.env.hermes-prod` |
+
+## Deferred (mechanics, not principle): migrating apps onto the prod base CVM
+Bulk-migrating the ~17 apps onto the prod base CVM (oauth3-prod7 / pod.dstack) is deferred,
+not rejected — pod.dstack is a general daemon meant to host dev and attested apps (mode is
+per-project, #16). Prerequisites:
+
+- `DAEMON_CONTAINER_RUNTIME=runc` on the prod base — the prod OS has no runsc
+- a resize of the target CVM
+- source pulls: 7 apps' sources exist only on the hermes-staging daemon disk
+- per-project secrets
+
+## Tidy-up
+Retire-able: the legacy Gen-1 enclave `oauth3-proxy-staging` (prod9) and the duplicate
+`shared-key-demo-2`. Longer-term: rename hermes-staging to end the staging/production
+confusion.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -26,6 +26,7 @@ Improvement proposals and design discussions for dstack-webhost.
 | [0020](0020-attestation-evidence-for-consumers.md) | Machine-Verifiable Attestation Evidence for App Consumers | Draft |
 | [0021](0021-app-self-improvement-evidence-spend.md) | App Self-Improvement via Attestation-Evidence Spend | Draft |
 | [0022](0022-spec-based-appraisal-curated-list.md) | Spec-Based Appraisal and Curated App List | Draft |
+| [0023](0023-staging-cvm-autonomous-dev.md) | Staging CVM Roles — webhost-staging vs hermes-staging | Draft |
 
 ## Conventions
 


### PR DESCRIPTION
## What it does
Adds the missing `rfcs/0023-staging-cvm-autonomous-dev.md` (it was named by `ship-fix.sh` and by RFC 0031's `td-0023` reference but absent from the tree) documenting the two staging CVMs as different layers, and registers it in `rfcs/README.md`.

## What you get by merging
The CVM-role knowledge that currently lives only in operator memory becomes a checked-in document: webhost-staging is the autonomous daemon-image test CVM (not retire-able), hermes-staging is the load-bearing production/app host where daemon-image dev cannot run, promotion to prod is the laptop-only `ship-fix.sh prod` step, and the deferred app-migration prerequisites are recorded concretely.

## Story
Closes #59. Acceptance restate:
- RFC states webhost-staging = autonomous daemon-image test CVM, hermes-staging = load-bearing production/app CVM, and that daemon-image dev cannot run on hermes-staging → `rfcs/0023` §Summary + the two role sections.
- `ship-fix.sh staging` → CVM `webhost-staging` + staging compose/env; `prod` → CVM `hermes-staging` + production compose/env; two targets visibly distinct in the script → **already true at origin/staging** (the `case` block, lines 13–15); script left untouched, verified below.
- Docs name daemon issues #57 (RFC 0017 export/import) and #58 (RFC 0026 scoped debug) as webhost-staging dependencies, and record promotion-to-prod as the laptop-only `ship-fix.sh prod` step → `rfcs/0023` §webhost-staging + §Ship flow.
- Deferred migration section records `DAEMON_CONTAINER_RUNTIME=runc`, a resize, source pulls for apps only on hermes-staging, per-project secrets → `rfcs/0023` §Deferred.

## Evidence (Tier 0)
No behavior change — one new markdown file + one index row; `ship-fix.sh` untouched.
- `bash -n ship-fix.sh` → exit 0.
- Routing block quoted verbatim from the script into the RFC's table; verified against `origin/staging`'s `ship-fix.sh` before writing.
- `test_daemon.py` not runnable as this account (rootless docker only; `test_daemon.py:115` pins `DOCKER_SOCKET=/var/run/docker.sock`, root:docker 660, uid swarm not in docker) — daemon behavior is unchanged by this PR; the overseer suite run gates the branch either way. Log: `~/paseo-batch/out/59/test.log`.

## Risk / what to watch
- `rfcs/README.md` index was already stale before this PR: 0025/0027/0028/0031 exist on disk but have no rows (0024 was never used; 0026 is being added by open PR #135). I added only the 0023 row to keep this diff scoped — worth a follow-up index sweep.
- Planner note: I followed the frontier plan (add RFC from scratch, preserve `ship-fix.sh`) and agreed with it after verifying the RFC is indeed absent at `origin/staging` and the script's routing already matches the acceptance exactly. No divergence.

<details>
<summary>Diff stats</summary>

```
 rfcs/0023-staging-cvm-autonomous-dev.md | 48 ++++++++++++++++++++++++++++++++++
 rfcs/README.md                          |  1 +
 2 files changed, 49 insertions(+)
```
</details>