### PR TITLE
docs(#119): a project is one container — multi-process workloads fold into one supervisor image

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -108,6 +108,26 @@ curl -X POST $CVM/_api/projects \
 
 The container runs under the daemon's configured OCI runtime (see `/_api/substrate`). On a CVM with `DAEMON_CONTAINER_RUNTIME=sysbox-runc`, all image-runtime apps get user-namespace remap and virtualised `/proc` for free. The container is placed on a per-project Docker network — sibling apps are not reachable by IP or hostname; only the daemon proxies traffic in and out. See the [isolation probe](isolation-probe.md) for a worked example.
 
+### Multi-process workloads: fold them into one image
+
+A project is **one container** — one handler for the language runtimes, one image for `runtime: "image"`. There is no manifest field for a second container, a sidecar, or a compose file; the daemon has no way to express one project spanning several containers. A workload of several cooperating services still deploys as one project by folding the services under a single supervisor **inside the image**, with one listening port for `image_port`.
+
+The worked case is Port Call (`amiller/port-call`), a meeting bot whose rig is four services: `postgres`, a transcription shim, a TTS shim, and `vexa-lite` — itself already a supervisor monolith (redis, Xvfb, fluxbox, pulseaudio, x11vnc, websockify, and its APIs). **All four fold.** Nothing needs its own container for isolation: the substrate isolates projects *from each other*, and processes inside one project share one trust boundary anyway. The fold happens at image-build time because the manifest has no `command:` override — the supervisor must be the image's `ENTRYPOINT` — and `vexa-lite` already runs under a supervisor, so `postgres` and the two shims are three more programs in its config, not a new deployment unit.
+
+What the fold owes the daemon:
+
+| | |
+|---|---|
+| Durable data → named `volumes` | A redeploy stops and removes the container and starts a fresh one; anything not on a named volume is lost. (Port Call's recordings lived in the container's `/tmp` and were lost on every recreate — port-call#26.) Put the postgres data directory and the recordings on `volumes: [{name, mount}]`; volumes are adopted idempotently, so data survives both recreate and redeploy. |
+| One port for `image_port` | Ingress proxies `/<name>/` to a single `image_port`. Services reach each other on container-internal ports; only the ingress-facing service needs to listen on `image_port`. |
+| Crash handling | The container restarts on non-zero exit (`on-failure`, 5 retries); the supervisor restarts an individual crashed service without the container being replaced. |
+| VPN routing | Two mechanisms, on different lines of this repo — see below. |
+| Resource envelope | None: the daemon sets no per-container memory or CPU limits, so a folded stack shares the CVM's whole envelope with every other project. That is the honest cost of the fold, and the point at which to consider a dedicated CVM instead. |
+
+**VPN routing.** Where the pod has a shared VPN egress network, set `egress: true` and the daemon joins the container to it and injects `EGRESS_PROXY_URL` / `ALL_PROXY` (`socks5://egress-vpn:1080`), so the app's outbound traffic routes through the pod's VPN. The VPN itself is another project — an attested image with `egress_provider: true` plus `cap_add: ["NET_ADMIN"]` and `devices: ["/dev/net/tun"]`. Caveat: this field landed on the `main` line (`d7fe947b`, 2026-07-03) and is not on the `staging` branch at the time of writing — a daemon built from `staging` silently ignores `egress`, so check `GET /_api/version` against your daemon before relying on it. The alternative every build carries: put your own VPN client in the image — `mode: "attested"` with the same `cap_add`/`devices` grant (rejected in dev mode; see RFC 0025).
+
+What does *not* fold is not a service but the concerns around it: separate lifecycles, separate resource envelopes, and CVM-level isolation between the services themselves. When a workload genuinely needs those — or already has a compose file it wants to keep — run it on a dedicated CVM under compose instead (Port Call's `docker-compose.cvm.yml`, in its own repo, is that shape). That burns a whole CVM on one app, which is exactly what folding avoids; treat it as the escape hatch, not the default.
+
 ## Promote to attested
 
 Promotion is the trust claim. The daemon records the source hash, opens the audit log, binds the hash into the TEE quote, and exposes the public verifier endpoints.

--- a/PLAN.md
+++ b/PLAN.md
@@ -117,3 +117,32 @@ PLAN — checkboxes derived from the issue's `## Acceptance`.
       start path exists, so `probe-121` never left "runtime not running"; the walk serves the
       branch's probe.py + index.html verbatim behind a handle() adapter);
       ghcr probe-image rebuild for hermes-staging remains the named operator step.
+
+---
+
+# Issue #119 plan — a project is one container; multi-service workloads fold into one image
+
+PLAN — checkboxes derived from the issue's `## Acceptance`. Tier 0: documentation only, no
+behavior change — no code touched.
+
+- [x] DEVELOPER_GUIDE.md, new "Multi-process workloads" subsection under Image runtime:
+      states plainly that a project is one container (no sidecar/compose/second-container
+      manifest field exists), and prescribes the supported path — fold processes under one
+      supervisor inside the image, one listening port for `image_port`.
+- [x] Written against Port Call's rig (postgres + transcription shim + TTS shim + vexa-lite):
+      says all four fold (vexa-lite is already a supervisor monolith; the manifest has no
+      `command:` override, so the supervisor must be the image's ENTRYPOINT) and names what
+      does NOT fold — separate lifecycles, separate resource envelopes, CVM-level isolation —
+      with the dedicated-CVM-under-compose path as the escape hatch.
+- [x] Durable data → named `volumes` (adopted idempotently, survive recreate AND redeploy;
+      port-call#26 recordings-in-/tmp as the failure case); crash handling (`on-failure`, 5
+      retries, supervisor restarts children without container replacement); no per-container
+      memory/CPU limits exists.
+- [x] VPN routing documented accurately per repo line: `egress`/`egress_provider` landed on
+      `main` (d7fe947b) — verified live on the prod7 daemon (`/_api/version` = fd0113fd,
+      which contains egress) — but NOT on `staging`, where `deploy_from_image` silently
+      ignores the flag; the guide says to check `/_api/version` before relying on it, and
+      documents the every-build alternative (attested `cap_add: ["NET_ADMIN"]` +
+      `devices: ["/dev/net/tun"]`, RFC 0025). Deliberate deviation from the issue's
+      "egress: true where VPN routing is needed": documented as deployed-real (main line)
+      rather than unconditionally, because this branch's code would silently no-op it.


### PR DESCRIPTION
## What it does

Documents the supported path for a multi-process workload on this daemon, in a new
**"Multi-process workloads: fold them into one image"** subsection of `DEVELOPER_GUIDE.md`'s
Image runtime section: a project is **one container** (no sidecar/compose/second-container
manifest field exists), so multi-service apps fold their processes under one supervisor
*inside the image*, with named `volumes` for anything that must survive a recreate.

## What you get by merging

The next tenant with a postgres-plus-shims-plus-headless-browser rig stops rediscovering the
answer privately: the guide states the one-container rule plainly, works the exact case the
issue names (Port Call: postgres + transcription shim + TTS shim + vexa-lite — **all four
fold**, since vexa-lite is already a supervisor monolith and the manifest has no `command:`
override, so the supervisor must be the image's ENTRYPOINT), and names the escape hatch (a
dedicated CVM under compose) with its real cost.

## Story

Closes #119. Acceptance restated:
- ✅ Documents the supported path today: one image with a supervisor, named volumes for
  durable data, VPN routing where needed.
- ✅ Written against Port Call's four services, saying which parts fold and which do not
  (what doesn't fold is not a service but separate lifecycles, separate resource envelopes,
  CVM-level isolation between the services).
- ✅ States plainly that a project is one container.

## Evidence — Tier 0 (documentation only, no behavior change)

Diff is two markdown files; code is bit-identical to `staging`. Every claim in the new
section was verified against this branch's code, plus one live check:

- One container per project: `start_image` (`proxy/runtimes.py`) creates exactly one
  container; redeploy stops/removes it; no manifest field adds a second.
- Volumes: `ensure_volume` is idempotent; the volume outlives the container across recreate
  and redeploy (port-call#26 recordings-in-`/tmp` cited as the failure case).
- Crash handling: `IMAGE_APP_RESTART_POLICY = on-failure ×5`; no per-container memory/CPU
  limits exist (`create_container` sets none).
- **VPN routing, corrected against both the issue and the plan I was handed:** `egress` /
  `egress_provider` are **not** on `staging` — this branch's `deploy_from_image` silently
  ignores the flag — but they **are** real and deployed: they landed on `main` in `d7fe947b`
  (2026-07-03), and the live prod7 daemon (`GET /_api/version` → `{"commit": "fd0113fd"}`,
  which contains `egress` in `proxy/`) runs them. The guide therefore documents `egress:
  true` as main-line-only and tells the reader to check `/_api/version` before relying on it,
  alongside the every-build alternative (attested `cap_add: ["NET_ADMIN"]` +
  `devices: ["/dev/net-tun"]`, RFC 0025). The plan I was given said "no egress manifest field
  or implementation" — true of this branch, false of the deployed daemon; I verified both
  rather than pick one.
- `docker-compose.cvm.yml` is in Port Call's repo, not this one — the text says "in its own
  repo" and links nothing here.

Rendered page for review: https://github.com/amiller/dstack-webhost/blob/staging-119/DEVELOPER_GUIDE.md#multi-process-workloads-fold-them-into-one-image

Tests:
- Unit: `proxy/test_docker_client.py`, `test_ladder.py`, `test_packaging.py` — **12 passed**
  (run with a real pytest runner; note `python -m proxy.test_*` exits 0 without running them).
- `python -m compileall proxy/` OK.
- `test_daemon.py`: **cannot complete in this sandbox** — docker here is rootless and its
  bridge netns is unreachable from the host (`curl <container-ip>` fails while the container
  runs and listens), so the first ingress-through-runtime test 504s. Tests before that
  boundary passed (auth, real deploy+pull, `/_api/version` commit pin). The overseer's
  rootful-docker gate should re-run it; a docs-only diff cannot change its outcome.

Backend-only — no visual evidence (no app surface changed).

## Risk / what to watch

Pure documentation. The one judgment call: the guide tells readers a `staging`-built daemon
silently ignores `egress` — if `staging` later merges `main`'s line, that sentence should be
dropped (the `/_api/version` check stays useful either way).

<details>
<summary>Diff stats</summary>

```
 DEVELOPER_GUIDE.md | 20 ++++++++++++++++++++
 PLAN.md           | 29 ++++++++++++++++++++++++++++++
 2 files changed, 49 insertions(+)
```

Commit: 67b81850 (`docs(#119): multi-process workloads fold into one image — a project is one container`)
</details>