### PR TITLE
deploy: never destroy files_dir on a failed or non-git clone (#130)

### DIFF
--- a/.evidence/issue-130/transcript.txt
+++ b/.evidence/issue-130/transcript.txt
@@ -1,0 +1,43 @@
+# Issue #130 / PR #140 — Tier 1 evidence (rework worker, 2026-08-31)
+
+Driver: one daemon + one multipart tarball project (source=tarball://demo), then
+POST /_api/projects/bugdemo/redeploy — the issue's ## Acceptance exercised over HTTP.
+BEFORE = origin/staging 3c4f1bb7 (PR base); AFTER = PR head 4b1d40cd. Both pinned via
+GET /_api/version. Daemon run from the checkout (identity from git, issue #106) with real
+docker (rootless, this box) inside the tee-test-runner container; files_dir and the stored
+manifest are read off disk, not off the API.
+
+===== BEFORE: origin/staging 3c4f1bb7 =====
+GET /_api/version -> 200 {'version': 'dev', 'commit': '3c4f1bb7'}
+POST /_api/projects (multipart tarball, source=tarball://demo) -> 201
+files_dir after deploy: ['index.html']
+stored manifest sha256[:12]: 2392d95727d6
+POST /_api/projects/bugdemo/redeploy -> 500 500 Internal Server Error
+
+Server got itself in trouble
+files_dir after redeploy: []
+stored manifest byte-identical: True (sha 2392d95727d6)
+GET /bugdemo/ after failed redeploy -> 404 ''
+DELETE /_api/projects/bugdemo -> 200 {"ok": true}
+
+===== AFTER: PR head 4b1d40cd =====
+GET /_api/version -> 200 {'version': 'dev', 'commit': '4b1d40cd'}
+POST /_api/projects (multipart tarball, source=tarball://demo) -> 201
+files_dir after deploy: ['index.html']
+stored manifest sha256[:12]: 58bf76c868d3
+POST /_api/projects/bugdemo/redeploy -> 400 {"error": "cannot re-clone source 'tarball://demo': not a fetchable git URL \u2014 a tarball-deployed project has no source to redeploy from; deploy new files via multipart upload"}
+files_dir after redeploy: ['index.html']
+stored manifest byte-identical: True (sha 58bf76c868d3)
+GET /bugdemo/ after failed redeploy -> 200 '<html><body><h1>Tarball deploy</h1></body></html>'
+DELETE /_api/projects/bugdemo -> 200 {"ok": true}
+
+## Full e2e suite at 4b1d40cd
+
+--- Test: tarball redeploy fails fast, preserves files + manifest (#130) ---
+  Redeploy rejected: cannot re-clone source 'tarball://local': not a fetchable git URL — a tarball-deployed project has no source to redeploy from; deploy new files via multipart upload
+  entry file + stored manifest byte-identical ✓
+--- Test: failed git_clone leaves an existing dest untouched (#130) ---
+  dest untouched, no stage left behind ✓
+=== ALL TESTS PASSED ===
+
+50 --- Test: blocks, exit 0. Full log: test-daemon-full.log (same directory on the box).

--- a/PLAN.md
+++ b/PLAN.md
@@ -117,3 +117,37 @@ PLAN — checkboxes derived from the issue's `## Acceptance`.
       start path exists, so `probe-121` never left "runtime not running"; the walk serves the
       branch's probe.py + index.html verbatim behind a handle() adapter);
       ghcr probe-image rebuild for hermes-staging remains the named operator step.
+
+---
+
+# Issue #130 — redeploy deletes a project's files when source is not a git URL
+
+PLAN — checkboxes derived from the issue's `## Acceptance`.
+
+## Root cause (verified in this tree at staging 3c4f1bb7)
+`git_clone()` rmtree's `dest` before the clone runs (deploy.py:56-57). `_api_redeploy`
+rebuilds a manifest carrying `source` (e.g. `tarball://feedling-web`) and calls `deploy()`
+with no `files_data` → git path → files erased, clone of `https://tarball://...` fails,
+`store.save()` never reached so the manifest still describes the deploy it just destroyed.
+`_api_redeploy` had no ValueError handler, so nothing returned a 4xx either.
+
+## Where the fix goes (deliberate deviation from the pre-spawn plan)
+The pre-planned approach put a source guard in `_api_redeploy` (ingress.py). I put it in
+`git_clone()` next to the URL-mangling that creates `https://tarball://...` in the first
+place, so the same fail-fast protects every caller: pinned import (RFC 0017), boot
+import-bootstrap, and a JSON `POST /_api/projects` over an existing project. The staging
+also lives in `git_clone` (clone into `dest + ".clone"`, swap only on success), so
+`deploy()` needs no changes — the existing `.pin` path composes unchanged. `_api_redeploy`
+gets only the ValueError→400 handler (mirroring `_api_deploy`).
+
+## Diff
+- [x] `proxy/deploy.py::git_clone`: reject a non-http(s) `://` source scheme before touching
+      the filesystem; clone + pinned checkout + rev-parses run in a staging sibling;
+      `dest` is replaced only after all of it succeeded; stage cleaned on every failure.
+- [x] `proxy/ingress.py::_api_redeploy`: ValueError → 400 with the message.
+- [x] `test_daemon.py::test_tarball_redeploy_preserves_project`: deploy tarball project →
+      POST redeploy → 4xx naming the reason, entry file present, stored manifest
+      byte-identical.
+- [x] `test_daemon.py::test_git_clone_failure_preserves_dest`: unclonable URL leaves a
+      pre-existing dest untouched, no `.clone` stage left behind.
+- [x] Existing `test_daemon.py` passes unchanged.

--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -59,40 +59,54 @@ async def git_clone(source: str, ref: str, dest: str,
 
     With commit_sha set (RFC 0017 pinned import), the full history is cloned
     and checked out at exactly that commit; a sha that no longer exists raises.
+
+    The clone lands in a staging sibling and replaces dest only after it
+    succeeded, so a failed clone never destroys what is already deployed (#130).
     """
-    if os.path.exists(dest):
-        shutil.rmtree(dest)
+    if "://" in source and not source.startswith(("https://", "http://")):
+        raise ValueError(
+            f"cannot re-clone source {source!r}: not a fetchable git URL — "
+            "a tarball-deployed project has no source to redeploy from; "
+            "deploy new files via multipart upload")
+    stage = dest + ".clone"
+    if os.path.exists(stage):
+        shutil.rmtree(stage)
     url = source if source.startswith(("https://", "http://", "/")) else f"https://{source}"
     cmd = ["git", "clone"]
     if not commit_sha:
         cmd += ["--depth", "1"]
         if ref:
             cmd += ["--branch", ref]
-    cmd += [url, dest]
+    cmd += [url, stage]
     proc = await asyncio.create_subprocess_exec(
         *cmd, stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
     _, stderr = await proc.communicate()
     if proc.returncode != 0:
+        shutil.rmtree(stage, ignore_errors=True)
         raise ValueError(f"git clone failed: {stderr.decode().strip()}")
     if commit_sha:
         proc = await asyncio.create_subprocess_exec(
-            "git", "-C", dest, "checkout", "--detach", commit_sha,
+            "git", "-C", stage, "checkout", "--detach", commit_sha,
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE)
         _, stderr = await proc.communicate()
         if proc.returncode != 0:
+            shutil.rmtree(stage, ignore_errors=True)
             raise ValueError(
                 f"pinned commit {commit_sha} not found in {source}: "
                 f"{stderr.decode().strip()}")
     proc2 = await asyncio.create_subprocess_exec(
-        "git", "-C", dest, "rev-parse", "HEAD",
+        "git", "-C", stage, "rev-parse", "HEAD",
         stdout=asyncio.subprocess.PIPE)
     stdout, _ = await proc2.communicate()
     commit_sha = stdout.decode().strip()
     proc3 = await asyncio.create_subprocess_exec(
-        "git", "-C", dest, "rev-parse", "HEAD^{tree}",
+        "git", "-C", stage, "rev-parse", "HEAD^{tree}",
         stdout=asyncio.subprocess.PIPE)
     stdout, _ = await proc3.communicate()
     git_tree_sha = stdout.decode().strip()
+    if os.path.exists(dest):
+        shutil.rmtree(dest)
+    shutil.move(stage, dest)
     return commit_sha, git_tree_sha
 
 

--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -843,8 +843,12 @@ class Ingress:
                 "port": project.listen.port,
                 "protocol": project.listen.protocol,
             }
-        project = await deploy(
-            self.store, self.docker, self.audit_manager, self.tracker, self.rtm, manifest)
+        try:
+            project = await deploy(
+                self.store, self.docker, self.audit_manager, self.tracker, self.rtm, manifest)
+        except ValueError as e:
+            # Bad source / port conflict etc. — the message is safe to return.
+            return web.json_response({"error": str(e)}, status=400)
         result = _redact_env(asdict(project))
         if project.runtime == "image":
             result["changed"] = project.image_digest != old_digest

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -588,6 +588,46 @@ def test_deploy_multipart_bad_json():
     print(f"  Got expected 400: {resp.json()}")
 
 
+def test_tarball_redeploy_preserves_project():
+    print("\n--- Test: tarball redeploy fails fast, preserves files + manifest (#130) ---")
+    proj_dir = os.path.join(tmpdir, "projects", "test-tarball")
+    with open(os.path.join(proj_dir, "project.json"), "rb") as f:
+        manifest_before = f.read()
+
+    resp = api_post("/projects/test-tarball/redeploy")
+    assert 400 <= resp.status_code < 500, \
+        f"expected 4xx, got {resp.status_code}: {resp.text}"
+    err = resp.json()["error"]
+    assert "not a fetchable git URL" in err and "tarball" in err, err
+    print(f"  Redeploy rejected: {err}")
+
+    assert os.path.isfile(os.path.join(proj_dir, "files", "index.html")), \
+        "entry file was deleted by the failed redeploy"
+    with open(os.path.join(proj_dir, "project.json"), "rb") as f:
+        assert f.read() == manifest_before, "stored manifest changed"
+    print("  entry file + stored manifest byte-identical \u2713")
+
+
+def test_git_clone_failure_preserves_dest():
+    print("\n--- Test: failed git_clone leaves an existing dest untouched (#130) ---")
+    import asyncio
+    from proxy.deploy import git_clone
+
+    dest = os.path.join(tmpdir, "clone-dest")
+    os.makedirs(dest)
+    with open(os.path.join(dest, "index.html"), "wb") as f:
+        f.write(b"<html>survivor</html>")
+    try:
+        asyncio.run(git_clone(os.path.join(tmpdir, "repos", "no-such-repo.git"), "", dest))
+        raise AssertionError("clone from a nonexistent repo should have failed")
+    except ValueError as e:
+        assert "git clone failed" in str(e), e
+    with open(os.path.join(dest, "index.html"), "rb") as f:
+        assert f.read() == b"<html>survivor</html>", "dest was destroyed"
+    assert not os.path.exists(dest + ".clone"), "staging dir left behind"
+    print("  dest untouched, no stage left behind \u2713")
+
+
 def test_redeploy():
     print("\n--- Test: redeploy after git push ---")
     old = api_get("/projects/test-static").json()
@@ -1710,6 +1750,8 @@ def main():
         test_deploy_multipart_missing_files()
         test_deploy_multipart_missing_manifest()
         test_deploy_multipart_bad_json()
+        test_tarball_redeploy_preserves_project()
+        test_git_clone_failure_preserves_dest()
         test_redeploy()
         test_audit_log()
         test_list_projects()


### PR DESCRIPTION
## What it does
`git_clone` no longer destroys a project's `files_dir` before it knows the clone can succeed. A source with a non-http(s) `://` scheme (e.g. `tarball://name`) is rejected up front with a 400-level reason, and real clones land in a `dest + ".clone"` staging sibling that replaces `dest` only after the clone (and any pinned checkout) succeeded — for every caller: deploy, redeploy, RFC 0017 pinned import, boot import-bootstrap. `_api_redeploy` now returns a `ValueError` as a 400 (mirroring `_api_deploy`) instead of a bare 500.

## What you get by merging
`POST /_api/projects/<n>/redeploy` can no longer erase a running project's code and leave the stored manifest describing the deploy it just deleted — the exact mechanism behind the ~45h `feedling-web` outage (issue #130). A tarball-deployed project now fails fast, in the response, naming the real reason.

## Story
Closes #130. Its `## Acceptance`:
- deploy a tarball project, redeploy → **(a)** 4xx naming the real reason, **(b)** `files_dir` still contains the entry file, **(c)** stored manifest byte-identical — ✅ demonstrated over HTTP below (and as `test_tarball_redeploy_preserves_project`).
- `git_clone` against a URL that cannot be cloned leaves a pre-existing `dest` untouched — ✅ `test_git_clone_failure_preserves_dest` (dest intact, no stage dir left behind).
- existing `test_daemon.py` passes unchanged — ✅ full suite green at the code commit, 50 `--- Test:` blocks, no existing test edited (+42/-0 in `test_daemon.py`).

## Evidence (Tier 1 — API behavior, no UI surface)
Real daemon + real docker, driven over HTTP by one driver (committed at `.evidence/issue-130/transcript.txt`). BEFORE is the PR's base `origin/staging` (3c4f1bb7); AFTER is this PR's code commit 4b1d40cd (the evidence-only commit on top, 9458415c, touches nothing but `.evidence/`). Both runs pin daemon identity via `GET /_api/version`; `files_dir` and the stored manifest are read off disk, not off the API:

```
===== BEFORE: origin/staging 3c4f1bb7 =====
GET /_api/version -> 200 {'version': 'dev', 'commit': '3c4f1bb7'}
POST /_api/projects (multipart tarball, source=tarball://demo) -> 201
files_dir after deploy: ['index.html']
stored manifest sha256[:12]: 2392d95727d6
POST /_api/projects/bugdemo/redeploy -> 500 500 Internal Server Error
files_dir after redeploy: []                    <-- the code, permanently deleted
stored manifest byte-identical: True            <-- manifest still describes the erased deploy
GET /bugdemo/ after failed redeploy -> 404 ''   <-- the outage surface

===== AFTER: PR head 4b1d40cd =====
GET /_api/version -> 200 {'version': 'dev', 'commit': '4b1d40cd'}
POST /_api/projects (multipart tarball, source=tarball://demo) -> 201
files_dir after deploy: ['index.html']
stored manifest sha256[:12]: 58bf76c868d3
POST /_api/projects/bugdemo/redeploy -> 400 {"error": "cannot re-clone source 'tarball://demo': not a fetchable git URL — a tarball-deployed project has no source to redeploy from; deploy new files via multipart upload"}
files_dir after redeploy: ['index.html']
stored manifest byte-identical: True (sha 58bf76c868d3)
GET /bugdemo/ after failed redeploy -> 200 '<html><body><h1>Tarball deploy</h1></body></html>'
```

Full e2e suite at 4b1d40cd: `=== ALL TESTS PASSED ===`, including both new #130 tests (log tail in details).

## What I could NOT verify from this sandbox
- The runs above are on this box's rootless docker inside the `tee-test-runner` container (the worker uid has no access to the system docker socket) — same disclosure as #141/#143; the overseer's gate run on system docker remains the authoritative suite result.
- The CVM ship (image build → ghcr push → `phala deploy` → `/_api/version` pinned on webhost-staging) needs credentials this account does not hold. webhost-staging currently pins `0336a7b3`; that ship step is the operator's.

## Risk / what to watch
- The swap (`rmtree(dest)` then `move(stage, dest)`) leaves a brief window where `dest` does not exist between a successful clone and the swap-in; the old code had that window from the start of every clone, so this strictly narrows it to post-success.
- A crashed daemon mid-clone can leave a `<files_dir>.clone` sibling behind; the next clone of the same project removes it first, and it is never served.
- Sources like `git@host:path` (no `://`) still take the pre-existing `https://{source}` prefixing path — unchanged behavior, not newly rejected.

<details><summary>diff stats + suite log tail</summary>

```
 PLAN.md          | 34 ++++++++++++++++++++++++++++++++++
 proxy/deploy.py  | 26 ++++++++++++++++++++------
 proxy/ingress.py |  8 ++++++--
 test_daemon.py   | 42 ++++++++++++++++++++++++++++++++++++++++++
 4 files changed, 102 insertions(+), 8 deletions(-)
 .evidence/issue-130/transcript.txt | committed at 9458415c
```

```
--- Test: tarball redeploy fails fast, preserves files + manifest (#130) ---
  Redeploy rejected: cannot re-clone source 'tarball://local': not a fetchable git URL — a tarball-deployed project has no source to redeploy from; deploy new files via multipart upload
  entry file + stored manifest byte-identical ✓
--- Test: failed git_clone leaves an existing dest untouched (#130) ---
  dest untouched, no stage left behind ✓
=== ALL TESTS PASSED ===
```
Full log: `test-daemon-full.log` in `~/paseo-batch/out/140/` on the box (50 `--- Test:` blocks, exit 0).
</details>