### PR TITLE
runtimes: give isolated (deno/bun) containers the same restart policy as image apps (#131)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -117,3 +117,20 @@ PLAN — checkboxes derived from the issue's `## Acceptance`.
       start path exists, so `probe-121` never left "runtime not running"; the walk serves the
       branch's probe.py + index.html verbatim behind a handle() adapter);
       ghcr probe-image rebuild for hermes-staging remains the named operator step.
+
+---
+
+# Issue #131 plan — isolated (deno/bun) containers get no restart policy
+
+PLAN — checkboxes derived from the issue's `## Acceptance`.
+
+- [x] `start_isolated` passes `IMAGE_APP_RESTART_POLICY` to `create_container`
+      (same one-line shape as `start_image`; `docker_client` already plumbed the kwarg).
+- [x] `test_isolated_restart_policy`: deploys an isolated deno app whose entry throws at
+      module load, asserts `HostConfig.RestartPolicy` on `tee-isolated-iso-restart-dev`
+      equals `IMAGE_APP_RESTART_POLICY`, then asserts docker actually retried
+      (`RestartCount > 0`); cleans up via `api_delete` like its sibling test.
+- [x] Full `test_daemon.py` green on real docker (`=== ALL TESTS PASSED ===`).
+- [x] Tier 1: HTTP transcript (deploy → inspect → pinned `/_api/version`) in the PR;
+      webhost-staging image deploy (`ship-fix.sh staging`) is operator-gated from this
+      sandbox (no ghcr push creds, no phala) — named in the PR, not papered over.

--- a/proxy/runtimes.py
+++ b/proxy/runtimes.py
@@ -603,6 +603,7 @@ class RuntimeManager:
         cid = await self.docker.create_container(
             cname, image, cmd, binds, labels, network,
             runtime=(project.oci_runtime or CONTAINER_RUNTIME),
+            restart_policy=IMAGE_APP_RESTART_POLICY,
             cap_add=caps, devices=devs)
         await self.docker.start(cid)
         self.tracker.add(cid)

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -15,6 +15,7 @@ import requests
 from playwright.sync_api import sync_playwright
 
 from proxy.docker_client import GVISOR_DNS
+from proxy.runtimes import IMAGE_APP_RESTART_POLICY
 
 DAEMON_PORT = 18080
 TEST_TOKEN = "test-secret-token-12345"
@@ -721,6 +722,41 @@ export default (_req: Request, ctx: {env: Record<string,string>}) => {
     assert r.json() == {"foo": "isolated-deno-passthrough"}, r.text
     print("  Handler saw FOO from daemon env via ctx.env ✓")
     api_delete("/projects/test-iso-passthru")
+
+
+def test_isolated_restart_policy():
+    print("\n--- Test: isolated container restart policy (issue #131) ---")
+    repo = create_test_repo("iso-restart", {
+        "project.json": json.dumps({"runtime": "deno", "isolation": "container",
+                                    "listen": {"port": 8080, "protocol": "http"}}).encode(),
+        # Top-level throw: the entry shim's import rejects, deno exits 1 —
+        # without a restart policy this container stays Exited forever.
+        "server.ts": b'throw new Error("crash on load");\n',
+    })
+    resp = api_post("/projects", json={"name": "iso-restart", "source": repo})
+    assert resp.status_code == 201, f"Deploy failed: {resp.text}"
+
+    cname = "tee-isolated-iso-restart-dev"
+    policy = json.loads(subprocess.run(
+        ["docker", "inspect", cname, "--format", "{{json .HostConfig.RestartPolicy}}"],
+        capture_output=True, text=True, check=True).stdout)
+    assert policy == IMAGE_APP_RESTART_POLICY, \
+        f"isolated container policy {policy} != image apps' {IMAGE_APP_RESTART_POLICY}"
+    print(f"  RestartPolicy={policy} (same as image apps) ✓")
+
+    # docker's on-failure backoff retries within seconds; a permanently
+    # broken app stops after MaximumRetryCount, which is the intended bound.
+    restarts = 0
+    for _ in range(40):
+        restarts = int(subprocess.run(
+            ["docker", "inspect", cname, "--format", "{{.RestartCount}}"],
+            capture_output=True, text=True, check=True).stdout)
+        if restarts > 0:
+            break
+        time.sleep(0.5)
+    assert restarts > 0, "docker never restarted the crashed isolated container"
+    print(f"  docker retried the crashed app: RestartCount={restarts} ✓")
+    api_delete("/projects/iso-restart")
 
 
 def test_dns_probe():
@@ -1702,6 +1738,7 @@ def main():
         test_isolated_per_project_data_volume()
         test_env_passthrough()
         test_isolated_deno_env_passthrough()
+        test_isolated_restart_policy()
         test_dns_probe()
         test_image_redeploy()
         test_substrate_endpoint()


### PR DESCRIPTION
## What it does
`start_isolated` now passes `IMAGE_APP_RESTART_POLICY` (`on-failure`, 5 retries) into `DockerClient.create_container` — the same one-liner shape `start_image` already had — so a crashed deno/bun container is retried by docker instead of sitting in `Exited (1)` forever. Adds `test_isolated_restart_policy` to the e2e suite.

## What you get by merging
A transient crash of an isolated app self-heals (docker restarts it, bounded at 5 tries); a pod restart or one failed start no longer becomes a 44-hour silent outage as it did for `tee-isolated-feedling-web-dev` on 2026-08-27. Isolated and image projects now behave identically here.

## Story
Closes #131. Its acceptance: (1) `start_isolated` passes a restart policy, asserted via `HostConfig.RestartPolicy` on the deno container matching the image policy; (2) a new test where an isolated container exiting non-zero is restarted by docker (`RestartCount > 0`); (3) existing `test_daemon.py` passes unchanged.

## Evidence (Tier 1 — backend/API change, no UI surface)
Live transcript — real daemon at this branch's commit, real docker, deploy through the public API (`POST /_api/projects`, entry `throw new Error("crash on load")`):

```
== POST /_api/projects  (isolated deno app whose entry throws at module load)
   HTTP 201
   {"name": "iso-crash-demo", "runtime": "deno", "entry": "server.ts", ...}
== docker inspect tee-isolated-iso-crash-demo-dev HostConfig.RestartPolicy
   {"Name":"on-failure","MaximumRetryCount":5}
== docker inspect RestartCount / State (after ~10s of retries)
   RestartCount=3  State=running ExitCode=1
== GET /_api/version
   {"version": "dev", "commit": "3e0e73e2"}
== teardown: DELETE /_api/projects/iso-crash-demo -> done
```

`commit: 3e0e73e2` is this PR's head. `State=running` with `ExitCode=1` and `RestartCount=3` is docker actively retrying the crashed app — the recovery the issue asks for; a permanently broken app still stops after 5 tries (the bounded choice the issue's Fix section names).

Full e2e suite on this branch: `=== ALL TESTS PASSED ===` including the new test (log in details). Backend-only — no visual evidence.

## What I could NOT verify from this sandbox
- The suite run above is on this box's rootless docker inside a containerized runner (the worker uid has no access to the system docker socket); the overseer's gate run on system docker remains the authoritative suite result.
- `ship-fix.sh staging` (image build → ghcr push → `phala deploy` → pin `/_api/version` on webhost-staging) needs ghcr push creds and the phala CLI, neither of which exists on this account. That deploy step is the operator's; the transcript above pins the commit on a locally-run daemon at the same tree instead.

## Notes vs. the pre-planned approach
The plan (pass `IMAGE_APP_RESTART_POLICY`, add an e2e test) was right; two deliberate deviations: the test cleans up after itself with `api_delete` like its sibling `test_isolated_deno_env_passthrough` rather than growing `test_teardown`'s legacy name list, and `RestartCount > 0` is asserted unconditionally — a live docker was available here, so no "if reliable" fallback branch was written.

## Risk / what to watch
One-line behavior change on the isolated path only; image/static/shared paths untouched. Watch: an app that crash-loops now gets 5 quick restarts (docker backoff 100ms→1.6s) before staying down — restart storms are bounded by `MaximumRetryCount=5`, same as image apps today.

<details><summary>diff stats + suite log tail</summary>

```
 proxy/runtimes.py |  1 +
 test_daemon.py   | 37 +++++++++++++++++++++
 PLAN.md          | 17 ++++++++
 3 files changed, 55 insertions(+)
```

```
--- Test: isolated container restart policy (issue #131) ---
  RestartPolicy={'Name': 'on-failure', 'MaximumRetryCount': 5} (same as image apps) ✓
  docker retried the crashed app: RestartCount=1 ✓
...
  All projects removed ✓
=== ALL TESTS PASSED ===
```
</details>