### PR TITLE
deploy: refuse an env that carries the redaction sentinel (#132)

### DIFF
--- a/.evidence/issue-132/transcript.md
+++ b/.evidence/issue-132/transcript.md
@@ -1,67 +1,67 @@
-# Issue #132 — refuse a deploy whose env carries `<redacted>` — evidence (Tier 1)
+# Issue #132 — refuse a deploy whose env carries `<redacted>` — evidence (Tier 1, rework 2026-08-31)
 
-All commands run on zed against a daemon started from the `staging-132` worktree
-(`python -m proxy.main`, fresh data dir, rootless docker), pinned below. The
-webhost-staging **image** deploy (`ship-fix.sh staging` → ghcr push → `phala deploy`)
-is operator-gated from this box: no write-scope ghcr credential and a dead phala API
-key — same blocker as `.evidence/issue-106/transcript.md` §5. Local daemon pinned to
-this PR's commit is the verifiable subset; the full `test_daemon.py` suite is green
-on the same tree (`=== ALL TESTS PASSED ===`, 49 tests, incl. the new
-`test_env_redaction_roundtrip_rejected`).
+Driver: `~/paseo-batch/out/142/drive.sh` on the box — every line below is a real HTTP call or
+a real file read, and the driver hard-asserts each one (it exits non-zero on any mismatch).
+One deno project whose `server.ts` echoes its env, so "the real secret reached the container"
+is observed, not assumed. BEFORE = PR base `origin/staging` 3c4f1bb7 — the bug; AFTER = PR
+head 8680e520 — the fix. Both runs pin daemon identity via `GET /_api/version` (identity is
+read from git at boot, issue #106; `DAEMON_COMMIT` was not set for either run). The stored
+manifest is hashed off disk (sha256), not taken from the API.
 
-## 1. Deploy with a REAL env is unaffected (201, response redacted)
-
-```
-$ curl -s -X POST :18081/_api/projects -H "$TOK" -H 'Content-Type: application/json' -d '{
-    "name": "redact132", "source": "/tmp/ev132/repo-redact132", "runtime": "deno", "entry": "server.ts",
-    "env": {"GITHUB_CLIENT_SECRET": "staging-real-secret-xyz", "POLL_INTERVAL_MIN": "5"}}'
-{"name": "redact132", "runtime": "deno", "entry": "server.ts", "port": 3000, "mode": "dev", "public": false, "env": {"GITHUB_CLIENT_SECRET": "<redacted>", "POLL_INTERVAL_MIN": "<redacted>"}, ... "commit_sha": "76f0fa9a0ea28a94aa577a252da61755c892f830", "tree_hash": "71d68cb53dbaddfead495c544297ba99f28c5c60", ...}
-```
-
-The deployed app echoes its env, proving the real values reached the container:
+## BEFORE — origin/staging 3c4f1bb7 (the 2026-08-24 oauth3 incident, reproduced)
 
 ```
-$ curl -s :18081/redact132/
-{"secret":"staging-real-secret-xyz","poll":"5"}
+GET /_api/version -> 200 {"version": "dev", "commit": "3c4f1bb7"}
+POST /_api/projects (real env) -> 201
+  {"name": "redact142", "runtime": "deno", "entry": "server.ts", "port": 3000, "mode": "dev",
+   "public": false, "env": {"GITHUB_CLIENT_SECRET": "<redacted>", "POLL_INTERVAL_MIN": "<redacted>"}, ...}
+GET /redact142/ (app echoes its env) -> 200 {"secret":"staging-real-secret-xyz","poll":"5"}
+stored manifest sha256[:12]: 79e09c89d5fa          (contains the real secret on disk)
+GET /_api/projects/redact142 -> env in body: {'GITHUB_CLIENT_SECRET': '<redacted>', 'POLL_INTERVAL_MIN': '<redacted>'}
+POST /_api/projects (the fetched body back, verbatim) -> 201
+  {"name": "redact142", ..., "env": {"GITHUB_CLIENT_SECRET": "<redacted>", "POLL_INTERVAL_MIN": "<redacted>"}, ...}
+stored manifest sha256[:12] now: e23b3a920a39 (was 79e09c89d5fa)   <-- the secrets were overwritten
+GET /redact142/ now -> {"secret":"<redacted>","poll":"<redacted>"} <-- the oauth3-2026-08-24 incident, reproduced
+POST /_api/projects (second project, no sentinel) -> 201
+DELETE /_api/projects/redact142, redact142b -> 200 {"ok": true}
 ```
 
-## 2. The round-trip that destroyed oauth3's secrets on 2026-08-24
-
-GET the project (this is what `deploy-prod-core.sh` serialized), then POST that
-exact body back:
+## AFTER — PR head 8680e520
 
 ```
-$ curl -s :18081/_api/projects/redact132 -H "$TOK" > fetched.json
-$ cat fetched.json
-{"name": "redact132", ..., "env": {"GITHUB_CLIENT_SECRET": "<redacted>", "POLL_INTERVAL_MIN": "<redacted>"}, ...}
-
-$ curl -s -w '\nHTTP %{http_code}\n' -X POST :18081/_api/projects -H "$TOK" \
-    -H 'Content-Type: application/json' -d @fetched.json
-{"error": "env keys GITHUB_CLIENT_SECRET, POLL_INTERVAL_MIN carry the redaction sentinel '<redacted>' — refusing to overwrite stored secrets with it"}
-HTTP 400
+GET /_api/version -> 200 {"version": "dev", "commit": "8680e520"}
+POST /_api/projects (real env) -> 201
+  {"name": "redact142", "runtime": "deno", "entry": "server.ts", "port": 3000, "mode": "dev",
+   "public": false, "env": {"GITHUB_CLIENT_SECRET": "<redacted>", "POLL_INTERVAL_MIN": "<redacted>"}, ...}
+GET /redact142/ (app echoes its env) -> 200 {"secret":"staging-real-secret-xyz","poll":"5"}
+stored manifest sha256[:12]: 31aa95d8f825          (contains the real secret on disk)
+GET /_api/projects/redact142 -> env in body: {'GITHUB_CLIENT_SECRET': '<redacted>', 'POLL_INTERVAL_MIN': '<redacted>'}
+POST /_api/projects (the fetched body back, verbatim) -> 400
+  {"error": "env keys GITHUB_CLIENT_SECRET, POLL_INTERVAL_MIN carry the redaction sentinel '<redacted>' — refusing to overwrite stored secrets with it"}
+stored manifest sha256[:12]: 31aa95d8f825 == 31aa95d8f825 (byte-identical)
+GET /redact142/ still -> 200 {"secret":"staging-real-secret-xyz","poll":"5"}
+POST /_api/projects (second project, no sentinel) -> 201
+DELETE /_api/projects/redact142, redact142b -> 200 {"ok": true}
 ```
 
-400 (not 201), and the message names both offending keys.
+Every `## Acceptance` line: the sentinel deploy returns **400 naming both keys**; the stored
+manifest is **byte-identical** and the pre-existing env **still in effect** (the app keeps
+serving the real secret); a sentinel-free deploy is **unaffected** (201).
 
-## 3. The stored secrets are untouched and still in effect
+## Full e2e suite at 8680e520
 
-```
-$ curl -s :18081/redact132/
-{"secret":"staging-real-secret-xyz","poll":"5"}
+`=== ALL TESTS PASSED ===` — 49 `--- Test:` blocks, exit 0, including the new
+`test_env_redaction_roundtrip_rejected` (400 + named keys + byte-identical stored
+`project.json`) and the version test pinning the running tree to 8680e520. No existing test
+was edited. Full log: `~/paseo-batch/out/142/test-daemon-full.log` on the box.
 
-$ python -c "import json; print(json.load(open('/tmp/ev132/data/redact132/project.json'))['env'])"
-{'GITHUB_CLIENT_SECRET': 'staging-real-secret-xyz', 'POLL_INTERVAL_MIN': '5'}
-```
+## Provenance / what this does not cover
 
-The regression test additionally asserts the on-disk `project.json` is byte-identical
-after the rejected deploy.
-
-## 4. Version pin
-
-```
-$ curl -s :18081/_api/version
-{"version": "dev", "commit": "d153c274"}
-```
-
-`d153c274` is this PR's head (`git rev-parse --short HEAD` in the worktree the daemon
-ran from; the suite's `test_version` pins the full sha to the running tree).
+Both daemons ran from the checkout inside the `tee-test-runner` container on this box's
+rootless docker (the worker uid has no access to the system docker socket, and rootless
+container IPs are not host-routable, so the daemon runs as a sibling of the app containers;
+checkout and state dirs are bind-mounted at identical paths inside and outside). The
+webhost-staging **image** ship (`ship-fix.sh staging` → ghcr push → `phala deploy`, then
+`/_api/version` pinned on webhost-staging) stays operator-gated from this box — no
+write-scope ghcr credential and a dead phala API key — same disclosure as PRs #140/#141;
+the overseer's suite run on the system docker socket remains the authoritative gate.

--- a/.evidence/issue-132/transcript.md
+++ b/.evidence/issue-132/transcript.md
@@ -1,0 +1,67 @@
+# Issue #132 — refuse a deploy whose env carries `<redacted>` — evidence (Tier 1)
+
+All commands run on zed against a daemon started from the `staging-132` worktree
+(`python -m proxy.main`, fresh data dir, rootless docker), pinned below. The
+webhost-staging **image** deploy (`ship-fix.sh staging` → ghcr push → `phala deploy`)
+is operator-gated from this box: no write-scope ghcr credential and a dead phala API
+key — same blocker as `.evidence/issue-106/transcript.md` §5. Local daemon pinned to
+this PR's commit is the verifiable subset; the full `test_daemon.py` suite is green
+on the same tree (`=== ALL TESTS PASSED ===`, 49 tests, incl. the new
+`test_env_redaction_roundtrip_rejected`).
+
+## 1. Deploy with a REAL env is unaffected (201, response redacted)
+
+```
+$ curl -s -X POST :18081/_api/projects -H "$TOK" -H 'Content-Type: application/json' -d '{
+    "name": "redact132", "source": "/tmp/ev132/repo-redact132", "runtime": "deno", "entry": "server.ts",
+    "env": {"GITHUB_CLIENT_SECRET": "staging-real-secret-xyz", "POLL_INTERVAL_MIN": "5"}}'
+{"name": "redact132", "runtime": "deno", "entry": "server.ts", "port": 3000, "mode": "dev", "public": false, "env": {"GITHUB_CLIENT_SECRET": "<redacted>", "POLL_INTERVAL_MIN": "<redacted>"}, ... "commit_sha": "76f0fa9a0ea28a94aa577a252da61755c892f830", "tree_hash": "71d68cb53dbaddfead495c544297ba99f28c5c60", ...}
+```
+
+The deployed app echoes its env, proving the real values reached the container:
+
+```
+$ curl -s :18081/redact132/
+{"secret":"staging-real-secret-xyz","poll":"5"}
+```
+
+## 2. The round-trip that destroyed oauth3's secrets on 2026-08-24
+
+GET the project (this is what `deploy-prod-core.sh` serialized), then POST that
+exact body back:
+
+```
+$ curl -s :18081/_api/projects/redact132 -H "$TOK" > fetched.json
+$ cat fetched.json
+{"name": "redact132", ..., "env": {"GITHUB_CLIENT_SECRET": "<redacted>", "POLL_INTERVAL_MIN": "<redacted>"}, ...}
+
+$ curl -s -w '\nHTTP %{http_code}\n' -X POST :18081/_api/projects -H "$TOK" \
+    -H 'Content-Type: application/json' -d @fetched.json
+{"error": "env keys GITHUB_CLIENT_SECRET, POLL_INTERVAL_MIN carry the redaction sentinel '<redacted>' — refusing to overwrite stored secrets with it"}
+HTTP 400
+```
+
+400 (not 201), and the message names both offending keys.
+
+## 3. The stored secrets are untouched and still in effect
+
+```
+$ curl -s :18081/redact132/
+{"secret":"staging-real-secret-xyz","poll":"5"}
+
+$ python -c "import json; print(json.load(open('/tmp/ev132/data/redact132/project.json'))['env'])"
+{'GITHUB_CLIENT_SECRET': 'staging-real-secret-xyz', 'POLL_INTERVAL_MIN': '5'}
+```
+
+The regression test additionally asserts the on-disk `project.json` is byte-identical
+after the rejected deploy.
+
+## 4. Version pin
+
+```
+$ curl -s :18081/_api/version
+{"version": "dev", "commit": "d153c274"}
+```
+
+`d153c274` is this PR's head (`git rev-parse --short HEAD` in the worktree the daemon
+ran from; the suite's `test_version` pins the full sha to the running tree).

--- a/PLAN.md
+++ b/PLAN.md
@@ -117,3 +117,21 @@ PLAN — checkboxes derived from the issue's `## Acceptance`.
       start path exists, so `probe-121` never left "runtime not running"; the walk serves the
       branch's probe.py + index.html verbatim behind a handle() adapter);
       ghcr probe-image rebuild for hermes-staging remains the named operator step.
+
+---
+
+# Issue #132 plan — reject a deploy whose env carries the literal <redacted>
+
+PLAN — checkboxes derived from the issue's `## Acceptance`.
+
+- [x] `POST /_api/projects` with a manifest whose env contains a `<redacted>` value returns
+      400 naming the offending key(s) and leaves the stored manifest unchanged (regression
+      test asserts the on-disk project.json is byte-identical after the rejected deploy).
+- [x] A deploy whose env carries no sentinel is unaffected (same test deploys real env first).
+- [x] The sentinel is defined once (`deploy.REDACTED`), referenced by both the ingress
+      redactor and the validator in `deploy()` (covers json, multipart, redeploy and import
+      — every env write goes through `deploy()`).
+- [x] Existing `test_daemon.py` passes unchanged — full suite green on real rootless docker;
+      the only test-file additions are the new test and its teardown entry.
+- [ ] webhost-staging image deploy (`ship-fix.sh staging`) — operator-gated: ghcr push
+      credentials are not on this box; local daemon pinned to this commit instead (PR body).

--- a/proxy/deploy.py
+++ b/proxy/deploy.py
@@ -28,6 +28,11 @@ NETWORK_ATTESTED = "tee-apps-attested"
 NAME_RE = re.compile(r"^[a-z0-9][a-z0-9-]*$")
 VALID_RUNTIMES = set(RUNTIME_CONFIG.keys()) | {"static", "dockerfile", "image"}
 
+# Sentinel ingress substitutes for every env value in project responses (issue
+# #67). Nothing legitimately deploys it: a client POSTing it back is round-
+# tripping a redacted GET and would overwrite real secrets (issue #132).
+REDACTED = "<redacted>"
+
 DEFAULT_ENTRY = {
     "deno": "server.ts", "bun": "index.ts", "node": "index.js",
     "python": "app.py", "static": ".", "dockerfile": "Dockerfile",
@@ -274,6 +279,13 @@ async def deploy(store: ProjectStore, docker: DockerClient, audit_manager,
 
     if not name or not NAME_RE.match(name):
         raise ValueError(f"Invalid project name: {name!r}")
+
+    redacted_keys = sorted(
+        k for k, v in (manifest.get("env") or {}).items() if v == REDACTED)
+    if redacted_keys:
+        raise ValueError(
+            f"env keys {', '.join(redacted_keys)} carry the redaction sentinel "
+            f"{REDACTED!r} — refusing to overwrite stored secrets with it")
 
     if manifest.get("runtime") == "image":
         return await _deploy_image(store, docker, audit_manager, rtm, manifest)

--- a/proxy/ingress.py
+++ b/proxy/ingress.py
@@ -19,7 +19,7 @@ from .docker_client import DockerClient
 from .projects import ProjectStore
 from .tracker import ContainerTracker
 from .audit import AuditLogManager, AuditEntry
-from .deploy import deploy, teardown, promote, unpromote, import_bundle
+from .deploy import deploy, teardown, promote, unpromote, import_bundle, REDACTED
 from . import runtimes as runtimes_mod
 from .runtimes import RuntimeManager
 from .tunnel import TunnelStore, TunnelResponse
@@ -55,7 +55,7 @@ def _redact_env(data: dict) -> dict:
     must never echo plaintext secrets back to the client or into logs; GET, status,
     deploy, redeploy, promote and aggregate all share this one rule."""
     if data.get("env"):
-        data["env"] = dict.fromkeys(data["env"], "<redacted>")
+        data["env"] = dict.fromkeys(data["env"], REDACTED)
     return data
 
 

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -1109,6 +1109,39 @@ def test_env_redaction():
     print("  deploy/status/list/promote all redact env \u2713")
 
 
+def test_env_redaction_roundtrip_rejected():
+    """Issue #132: a client that GETs a project and POSTs the redacted env
+    back (what deploy-prod-core.sh did on 2026-08-24) must be refused, not
+    silently overwrite real secrets with the sentinel."""
+    print("\n--- Test: deploy carrying <redacted> env is rejected (issue #132) ---")
+    repo = create_test_repo("test-redact-rt", {"index.html": b"roundtrip"})
+    secret_env = {"POLL_INTERVAL_MIN": "5", "GITHUB_CLIENT_SECRET": "super-secret-value-xyz"}
+    resp = api_post("/projects", json={
+        "name": "test-redact-rt", "source": repo, "runtime": "static",
+        "env": secret_env,
+    })
+    assert resp.status_code == 201, f"clean deploy failed: {resp.text}"
+    stored_path = os.path.join(tmpdir, "projects", "test-redact-rt", "project.json")
+    with open(stored_path) as f:
+        stored = json.load(f)
+    assert stored["env"] == secret_env, f"real env not stored: {stored['env']}"
+
+    # Round-trip: POST the GET response back verbatim — sentinel env, 400.
+    fetched = api_get("/projects/test-redact-rt").json()
+    assert fetched["env"] == dict.fromkeys(secret_env, "<redacted>"), fetched["env"]
+    resp = api_post("/projects", json=fetched)
+    assert resp.status_code == 400, f"sentinel deploy accepted: {resp.status_code}"
+    assert "GITHUB_CLIENT_SECRET" in resp.text and "POLL_INTERVAL_MIN" in resp.text, resp.text
+    print(f"  round-tripped manifest rejected ({resp.status_code}), keys named \u2713")
+
+    # The stored manifest is untouched: real secrets still in effect.
+    with open(stored_path) as f:
+        assert json.load(f) == stored, "rejected deploy mutated the stored manifest"
+    assert api_get("/projects/test-redact-rt").json()["env"] == \
+        dict.fromkeys(secret_env, "<redacted>")
+    print("  stored manifest unchanged, real env still in effect \u2713")
+
+
 def test_root_listing_layers():
     """The public root listing drives the 3-layer console: anonymous sees only the
     attested surface plus a `hidden` count (the #43 pointer); an owner bearer sees
@@ -1666,7 +1699,7 @@ def test_rfc0017_bootstrap():
 
 def test_teardown():
     print("\n--- Test: teardown ---")
-    for name in ["test-static", "test-caps", "test-deno", "test-auto", "test-tarball", "test-image", "test-iso-a", "test-iso-b", "test-passthru", "test-iso-passthru", "test-redeploy-img", "test-redact", "net-a", "net-b", "data-iso", "rfc-test", "test-opdebug", "test-opdebug-off", "tier0-src", "test-exp"]:
+    for name in ["test-static", "test-caps", "test-deno", "test-auto", "test-tarball", "test-image", "test-iso-a", "test-iso-b", "test-passthru", "test-iso-passthru", "test-redeploy-img", "test-redact", "test-redact-rt", "net-a", "net-b", "data-iso", "rfc-test", "test-opdebug", "test-opdebug-off", "tier0-src", "test-exp"]:
         resp = api_delete(f"/projects/{name}")
         if resp.status_code == 200:
             print(f"  Torn down: {name}")
@@ -1714,6 +1747,7 @@ def main():
         test_audit_log()
         test_list_projects()
         test_env_redaction()
+        test_env_redaction_roundtrip_rejected()
         test_root_listing_layers()
         test_landing_cards()
         test_landing_descriptions()


### PR DESCRIPTION
## What it does
`deploy()` refuses, with a 400 naming the offending keys, any incoming `env` that carries the redaction sentinel `<redacted>`. The sentinel is one shared constant (`deploy.REDACTED`) referenced by both the ingress redactor (since #67) and the new check, which sits before any clone/extract/image work — so every env write path (json, multipart, redeploy, import) is covered once.

## What you get by merging
A client that GETs a project manifest and POSTs it back (what `deploy-prod-core.sh` did to `oauth3` on 2026-08-24) can no longer overwrite real secrets with the literal string `<redacted>`. Today the daemon accepts that write silently and the values are unrecoverable — `egress-vpn`'s `OPENVPN_USER`/`OPENVPN_PASS`/`OVPN_CONFIG_BASE64` have no copy outside the pod at all.

## Story
Closes #132. Its `## Acceptance`, each line demonstrated over HTTP below:
- sentinel deploy → **400 naming the key(s)**, stored manifest **unchanged** (byte-identical sha, real env still in effect — the app keeps serving the real secret) — ✅ AFTER transcript.
- a deploy with no sentinel is **unaffected** — ✅ second project deploys 201 in both runs.
- sentinel **defined once**, referenced by redactor and validator — ✅ `deploy.REDACTED` (the only two occurrences in the diff).
- existing `test_daemon.py` passes **unchanged** — ✅ full suite green at the head commit, 49 `--- Test:` blocks, no existing test edited.

## Evidence (Tier 1 — API behavior, no UI surface)
Real daemon + real docker, driven over HTTP by one driver (committed at `.evidence/issue-132/transcript.md`; driver kept on the box at `~/paseo-batch/out/142/drive.sh`). BEFORE is the PR's base `origin/staging` 3c4f1bb7 — it reproduces the 2026-08-24 incident exactly; AFTER is this PR's code commit 8680e520. Both runs pin daemon identity via `GET /_api/version` (identity read from git at boot, issue #106). The stored manifest is hashed off disk, not read via the API:

```
===== BEFORE: origin/staging 3c4f1bb7 =====
GET /_api/version -> 200 {"version": "dev", "commit": "3c4f1bb7"}
POST /_api/projects (real env) -> 201 (response env redacted, as designed by #67)
GET /redact142/ (app echoes its env) -> 200 {"secret":"staging-real-secret-xyz","poll":"5"}
stored manifest sha256[:12]: 79e09c89d5fa
GET /_api/projects/redact142 -> env: {'GITHUB_CLIENT_SECRET': '<redacted>', 'POLL_INTERVAL_MIN': '<redacted>'}
POST /_api/projects (the fetched body back, verbatim) -> 201
stored manifest sha256[:12] now: e23b3a920a39 (was 79e09c89d5fa)   <-- the secrets were overwritten
GET /redact142/ now -> {"secret":"<redacted>","poll":"<redacted>"} <-- the oauth3-2026-08-24 incident, reproduced

===== AFTER: PR head 8680e520 =====
GET /_api/version -> 200 {"version": "dev", "commit": "8680e520"}
POST /_api/projects (real env) -> 201 (response env redacted)
GET /redact142/ -> 200 {"secret":"staging-real-secret-xyz","poll":"5"}
stored manifest sha256[:12]: 31aa95d8f825
GET /_api/projects/redact142 -> env: {'GITHUB_CLIENT_SECRET': '<redacted>', 'POLL_INTERVAL_MIN': '<redacted>'}
POST /_api/projects (the fetched body back, verbatim) -> 400
  {"error": "env keys GITHUB_CLIENT_SECRET, POLL_INTERVAL_MIN carry the redaction sentinel '<redacted>' — refusing to overwrite stored secrets with it"}
stored manifest sha256[:12]: 31aa95d8f825 == 31aa95d8f825 (byte-identical)
GET /redact142/ still -> 200 {"secret":"staging-real-secret-xyz","poll":"5"}
POST /_api/projects (second project, no sentinel) -> 201
```

Full e2e suite at 8680e520: `=== ALL TESTS PASSED ===`, 49 `--- Test:` blocks, exit 0, including the new `test_env_redaction_roundtrip_rejected` (400 + named keys + byte-identical stored `project.json`) (log tail in details).

## What I could NOT verify from this sandbox
- The runs above are on this box's **rootless docker** inside the `tee-test-runner` container (the worker uid has no access to the system docker socket) — same disclosure as #140/#141; the overseer's gate run on system docker remains the authoritative suite result.
- The CVM ship (image build → ghcr push → `phala deploy` → `/_api/version` pinned on webhost-staging) needs credentials this account does not hold; that ship step is the operator's.

## Risk / what to watch
- The check runs before clone/extraction, so a rejected deploy costs nothing on disk; nothing legitimate deploys the literal `<redacted>` (a redacted GET is the only producer).
- A manifest that *legitimately* wants a value equal to the sentinel is refused — by design (issue #132 argues rejecting beats silently preserving the stored value, which would disagree with the manifest the caller believes it deployed).

<details><summary>diff stats + suite log tail</summary>

```
 PLAN.md          | 18 +++++++++++
 proxy/deploy.py  | 12 ++++++
 proxy/ingress.py |  4 +-
 test_daemon.py   | 36 ++++++++++++++-
 5 files changed, 134 insertions(+), 3 deletions(-)   (incl. .evidence/issue-132/transcript.md)
 evidence-only rework commit: 43829dce (rewrote the transcript with correct BEFORE/AFTER pins)
```

```
--- Test: deploy carrying <redacted> env is rejected (issue #132) ---
  round-tripped manifest rejected (400), keys named ✓
  stored manifest unchanged, real env still in effect ✓
--- Test: version endpoint ---
  Version: dev commit: 8680e520 ✓
=== ALL TESTS PASSED ===
```
Full log: `test-daemon-full.log` in `~/paseo-batch/out/142/` on the box (49 `--- Test:` blocks, exit 0).
</details>