### PR TITLE
daemon: pull private registry images via X-Registry-Auth

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -99,10 +99,12 @@ curl -X POST $CVM/_api/projects \
 
 | Field | Purpose |
 |---|---|
-| `image` | OCI reference. Pin by digest for attestable deploys. |
+| `image` | OCI reference. Pin by digest for attestable deploys. Public registries pull anonymously; for a **private** image, give the daemon registry creds (below) — no need to flip the package to public. |
 | `image_port` | Port the container listens on internally; ingress proxies path-based at `/<name>/`. |
 | `volumes` | Optional `[{name, mount}]`. Named volumes are referenced by name and adopted idempotently — pre-existing data survives. |
 | `env_passthrough` | Optional list of env-var names; the daemon forwards values from its own environment, keeping secrets out of `project.json`. |
+
+**Private registry pulls.** Set registry creds in the daemon's own environment and it sends them as `X-Registry-Auth` on pulls — a private image works without ever making the package public. Either `GHCR_USERNAME` + `GHCR_TOKEN` (a token with `read:packages`) for `ghcr.io`, or the general `REGISTRY_AUTHS` = a JSON map of `{"<registry-host>": {"username": "...", "password": "..."}}`. Creds live in the sealed CVM env, never in `project.json`. Public pulls are unchanged.
 
 The container runs under the daemon's configured OCI runtime (see `/_api/substrate`). On a CVM with `DAEMON_CONTAINER_RUNTIME=sysbox-runc`, all image-runtime tenants get user-namespace remap and virtualised `/proc` for free. The container is placed on a per-project Docker network — sibling tenants are not reachable by IP or hostname; only the daemon proxies traffic in and out. See the [isolation probe](isolation-probe.md) for a worked example.
 

--- a/proxy/docker_client.py
+++ b/proxy/docker_client.py
@@ -1,10 +1,40 @@
 """Thin async Docker Engine client over Unix socket."""
 
+import base64
+import json
 import logging
+import os
 
 import aiohttp
 
 log = logging.getLogger(__name__)
+
+
+def _registry_host(image: str) -> str:
+    first = image.split("/", 1)[0]
+    return first if ("." in first or ":" in first) else "docker.io"
+
+
+def _registry_auth(image: str) -> str | None:
+    """X-Registry-Auth header value (base64 JSON) for a private pull, from daemon env.
+
+    Two sources, in order: REGISTRY_AUTHS (JSON map host -> {username, password}), then the
+    GHCR_USERNAME/GHCR_TOKEN convenience pair for ghcr.io. Returns None if no creds match the
+    image's registry, so public pulls are unchanged."""
+    host = _registry_host(image)
+    creds = None
+    raw = os.environ.get("REGISTRY_AUTHS")
+    if raw:
+        try:
+            creds = json.loads(raw).get(host)
+        except (ValueError, AttributeError):
+            log.warning("REGISTRY_AUTHS is not valid JSON; ignoring")
+    if not creds and host == "ghcr.io" and os.environ.get("GHCR_USERNAME") and os.environ.get("GHCR_TOKEN"):
+        creds = {"username": os.environ["GHCR_USERNAME"], "password": os.environ["GHCR_TOKEN"]}
+    if not creds:
+        return None
+    auth = {"username": creds["username"], "password": creds["password"], "serveraddress": host}
+    return base64.b64encode(json.dumps(auth).encode()).decode()
 
 # Docker's embedded resolver (127.0.0.11, forced on user-defined bridge
 # networks) is dead under gVisor: the Sentry netstack never applies the host
@@ -121,8 +151,18 @@ class DockerClient:
     PULL_TIMEOUT = 120
 
     async def pull(self, image: str):
+        # Digest refs (repo@sha256:...) must be split into fromImage + tag for the engine.
+        if "@" in image:
+            repo, _, digest = image.partition("@")
+            query = f"fromImage={repo}&tag={digest}"
+        else:
+            query = f"fromImage={image}"
+        headers = {}
+        auth = _registry_auth(image)  # private registry (e.g. ghcr) creds from daemon env, if any
+        if auth:
+            headers["X-Registry-Auth"] = auth
         status, body = await self._raw_request(
-            "POST", f"/images/create?fromImage={image}", timeout=self.PULL_TIMEOUT)
+            "POST", f"/images/create?{query}", timeout=self.PULL_TIMEOUT, headers=headers)
         if status >= 400:
             # Registry unreachable / rate-limited is fine if the image is already
             # cached locally — use the cached image rather than blocking the deploy.

--- a/proxy/test_docker_client.py
+++ b/proxy/test_docker_client.py
@@ -5,8 +5,11 @@ is dead under the gVisor netstack (issue #2). Every other runtime must stay
 untouched so runc tenants keep Docker's embedded resolver."""
 
 import asyncio
+import base64
+import json
+import os
 
-from .docker_client import GVISOR_DNS, DockerClient
+from .docker_client import GVISOR_DNS, DockerClient, _registry_auth
 
 
 def _capturing_client():
@@ -40,3 +43,62 @@ def test_runc_and_shared_creates_keep_embedded_dns():
         _create(dc, runtime)
         hc = captured["body"]["HostConfig"]
         assert "Dns" not in hc, f"runtime={runtime!r} must keep the embedded resolver"
+
+
+def _pull_capturing_client():
+    captured = {}
+
+    async def fake_raw(method, path, timeout=300, headers=None, **kw):
+        captured["path"] = path
+        captured["headers"] = headers or {}
+        return 200, b""
+
+    dc = DockerClient("/nonexistent/docker.sock")
+    dc._raw_request = fake_raw
+    return captured, dc
+
+
+def _with_env(**kv):
+    saved = {k: os.environ.get(k) for k in kv}
+    os.environ.update({k: v for k, v in kv.items() if v is not None})
+    return saved
+
+
+def _restore_env(saved):
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def test_registry_auth_public_none_ghcr_from_env():
+    saved = _with_env(GHCR_USERNAME="u", GHCR_TOKEN="t", REGISTRY_AUTHS=None)
+    try:
+        assert _registry_auth("node:24-slim") is None
+        auth = json.loads(base64.b64decode(_registry_auth("ghcr.io/o/r@sha256:abc")))
+        assert auth == {"username": "u", "password": "t", "serveraddress": "ghcr.io"}
+    finally:
+        _restore_env(saved)
+
+
+def test_pull_private_ghcr_sends_auth_and_splits_digest():
+    saved = _with_env(GHCR_USERNAME="u", GHCR_TOKEN="t")
+    try:
+        captured, dc = _pull_capturing_client()
+        asyncio.run(dc.pull("ghcr.io/o/r@sha256:abc123"))
+        assert "fromImage=ghcr.io/o/r&tag=sha256:abc123" in captured["path"]
+        assert "X-Registry-Auth" in captured["headers"]
+    finally:
+        _restore_env(saved)
+
+
+def test_pull_public_sends_no_auth():
+    saved = _with_env(GHCR_USERNAME=None, GHCR_TOKEN=None, REGISTRY_AUTHS=None)
+    try:
+        captured, dc = _pull_capturing_client()
+        asyncio.run(dc.pull("node:24-slim"))
+        assert "fromImage=node:24-slim" in captured["path"]
+        assert "X-Registry-Auth" not in captured["headers"]
+    finally:
+        _restore_env(saved)


### PR DESCRIPTION
## What
Let image-runtime tenants use a **private** image (e.g. a private `ghcr.io` package) without flipping the package to public.

`DockerClient.pull` now reads registry creds from the daemon's own env and sends them as `X-Registry-Auth` on `POST /images/create`:
- `GHCR_USERNAME` + `GHCR_TOKEN` (a token with `read:packages`) for `ghcr.io`, or
- `REGISTRY_AUTHS` = a JSON map `{"<host>": {"username": "...", "password": "..."}}` for any registry.

Creds live in the sealed CVM env, never in `project.json`. If no creds match the image's registry, no header is sent, so **public pulls are unchanged**.

Also splits a digest ref (`repo@sha256:...`) into `fromImage` + `tag` so the engine pulls pinned digests correctly — the pin-by-digest path the guide recommends for attestable deploys.

## Why
Today the daemon pulls anonymously, so a private ghcr package 500s until its visibility is flipped to public (per the developer guide). That forces every image-runtime tenant to be world-pullable. This adds an opt-in, env-configured auth path so private images just work.

## Notes
- No behavior change without creds set — additive and backward compatible.
- Docs: DEVELOPER_GUIDE image-runtime section documents the env.
- Verified: `_registry_auth` unit-checked (public -> None; ghcr env -> correct base64 auth JSON; `REGISTRY_AUTHS` precedence); module parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)