### PR TITLE
ci: build+push the daemon image on every push to staging; ship-fix.sh staging --no-build needs no ghcr credential (#146)

### DIFF
--- a/.evidence/issue-146/harness-transcript.txt
+++ b/.evidence/issue-146/harness-transcript.txt
@@ -1,0 +1,44 @@
+# ship-fix.sh --no-build verification — 2026-09-09T19:11:40Z, zed (uid swarm)
+# Real ghcr (anonymous, package is public). phala is stubbed (logs argv, touches no CVM);
+# the staging compose is a stub in $HOME mirroring the real file's image-pin line.
+# Happy path forces TAG to staging-0b830666 (a real tag CI-equivalent); all downstream code is as shipped.
+
+## TEST 1 (acceptance 3): HEAD not CI-built -> refuse, name the tag, change nothing
+$ bash ship-fix.sh staging --no-build   (HEAD=5c5dd3ec)
+==> 1/4 build: skipped (--no-build — CI built the image on the push to staging)
+==> 2/4 resolve digest of ghcr.io/amiller/tee-socket-proxy:staging-5c5dd3e from ghcr (package is public: anonymous pull, no ghcr login)
+no CI-built image for this commit: ghcr.io/amiller/tee-socket-proxy:staging-5c5dd3e (ghcr HTTP 404) — push 5c5dd3ec to staging so CI builds it, or ship without --no-build
+exit=1
+compose sha256 unchanged: OK
+phala invocations: 0
+
+## TEST 2 (acceptance 2 mechanics): existing tag -> resolve, repin, deploy; NO docker build/push
+==> 1/4 build: skipped (--no-build — CI built the image on the push to staging)
+==> 2/4 resolve digest of ghcr.io/amiller/tee-socket-proxy:staging-0b830666 from ghcr (package is public: anonymous pull, no ghcr login)
+    resolved: ghcr.io/amiller/tee-socket-proxy@sha256:8724ffa39e503b9dc4be373a05cfe77c26efdebb5706c8bbc7d0630fdfca5d29
+==> 3/4 point staging compose at the new digest
+3:    image: ghcr.io/amiller/tee-socket-proxy@sha256:8724ffa39e503b9dc4be373a05cfe77c26efdebb5706c8bbc7d0630fdfca5d29
+==> 4/4 upgrade webhost-staging CVM (restarts every service in the compose; sealed env re-supplied)
+
+DONE (staging -> webhost-staging).
+exit=0
+compose image line now:     image: ghcr.io/amiller/tee-socket-proxy@sha256:8724ffa39e503b9dc4be373a05cfe77c26efdebb5706c8bbc7d0630fdfca5d29
+independent check (docker manifest inspect --verbose): sha256:8724ffa39e503b9dc4be373a05cfe77c26efdebb5706c8bbc7d0630fdfca5d29
+phala invoked with: PHALA-STUB argv: deploy --cvm-id webhost-staging -c /home/swarm/projects/hermes-agent/docker-compose.webhost-staging.yaml -e /home/swarm/projects/hermes-agent/deploy-notes/.env.webhost-staging --wait
+docker build|push lines in transcript: 0
+
+## TEST 3: --no-build is staging-only
+--no-build is staging-only: CI builds images only on pushes to staging
+exit=1
+
+## TEST 4: unknown option refused
+unknown option '--frobnicate' (only --no-build)
+exit=1
+
+## TEST 5: compose without a digest pin -> refuse to deploy stale image
+==> 1/4 build: skipped (--no-build — CI built the image on the push to staging)
+==> 2/4 resolve digest of ghcr.io/amiller/tee-socket-proxy:staging-0b830666 from ghcr (package is public: anonymous pull, no ghcr login)
+    resolved: ghcr.io/amiller/tee-socket-proxy@sha256:8724ffa39e503b9dc4be373a05cfe77c26efdebb5706c8bbc7d0630fdfca5d29
+==> 3/4 point staging compose at the new digest
+compose was not repinned to ghcr.io/amiller/tee-socket-proxy@sha256:8724ffa39e503b9dc4be373a05cfe77c26efdebb5706c8bbc7d0630fdfca5d29 — no ghcr.io/amiller/tee-socket-proxy@sha256 pin to replace; refusing to deploy a stale image
+exit=1

--- a/.github/workflows/staging-image.yml
+++ b/.github/workflows/staging-image.yml
@@ -1,0 +1,45 @@
+# Builds and pushes the daemon image on every push to staging (issue #146), so a
+# staging roll needs no ghcr credential on the shipping machine:
+# `ship-fix.sh staging --no-build` resolves this tag's digest anonymously and deploys.
+name: staging-image
+on:
+  push:
+    branches: [staging]
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      digest: ${{ steps.push.outputs.digest }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Log in to ghcr
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Build and push
+        id: push
+        env:
+          IMG: ghcr.io/amiller/tee-socket-proxy
+        run: |
+          # Tag contract with ship-fix.sh: staging-<first 7 hex of the sha>. NOT
+          # `git rev-parse --short`, whose width is object-count dependent — a shallow
+          # checkout says 7 chars, a full clone 8, and the widths must never disagree.
+          SHORT="${GITHUB_SHA:0:7}"
+          TAG="$IMG:staging-$SHORT"
+          docker build --build-arg GIT_COMMIT="$SHORT" -t "$TAG" .
+          PUSH_LOG=$(mktemp)
+          docker push "$TAG" | tee "$PUSH_LOG"
+          SHA=$(sed -n 's/.*digest: \(sha256:[a-f0-9]\{64\}\).*/\1/p' "$PUSH_LOG" | tail -1)
+          rm -f "$PUSH_LOG"
+          [ -n "$SHA" ] || { echo "push printed no digest — refusing to guess what was pushed" >&2; exit 1; }
+          echo "digest=$SHA" >> "$GITHUB_OUTPUT"
+          {
+            echo "## staging image"
+            echo "- tag: \`$TAG\`"
+            echo "- digest: \`$IMG@$SHA\`"
+            echo "- commit: \`$SHORT\`"
+            echo "Ship it: \`ship-fix.sh staging --no-build\` (no ghcr login needed)."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ node_modules/
 .venv/
 smithers.db*
 deploy/
-workflows/
+/workflows/
 tsconfig.json
 package.json
 package-lock.json

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -216,6 +216,10 @@ Two limits to plan around:
 - **`/oauth3/sdk.js` is fetched at runtime**, so it is not covered by your project's measured tree
   hash. If your project is `attested`, vendor the SDK into your own tree instead.
 
+## Shipping the daemon itself
+
+Two paths roll a CVM to a new daemon image, both through `ship-fix.sh`. **CI-built (staging, no ghcr credential):** every push to `staging` makes [`.github/workflows/staging-image.yml`](.github/workflows/staging-image.yml) build the `Dockerfile` and push `ghcr.io/amiller/tee-socket-proxy:staging-<short sha>` with the workflow's own `GITHUB_TOKEN`; `ship-fix.sh staging --no-build` then resolves that tag's digest anonymously from ghcr (the package is public), pins it in the staging compose and `phala deploy`s — and refuses, changing nothing, if CI has not built an image for HEAD. **Local (any target):** plain `ship-fix.sh staging|prod|pod` builds and pushes the image itself, so it needs `docker login ghcr.io` on the shipping machine.
+
 ## Where to look in the daemon
 
 `proxy/ingress.py` has the request routing and auth gate. `proxy/runtimes.py` has the language-runtime container management and the Deno router that loads your handler. `proxy/deploy.py` has the git-clone path and the source-hash recording. The whole thing is small enough to read end-to-end.

--- a/ship-fix.sh
+++ b/ship-fix.sh
@@ -4,10 +4,15 @@
 #   prod    -> hermes-staging CVM (load-bearing; its env/token live only on the laptop)
 #   pod     -> oauth3-prod7, i.e. pod.dstack.soc1024.com (Base KMS: the new compose hash
 #              is registered on-chain, so this target needs PRIVATE_KEY in the environment)
-# Prereqs: `docker login ghcr.io` done; Phala dashboard open (restart can be finicky).
+# `--no-build` (staging only) ships the image CI built for HEAD on the push to staging
+# (.github/workflows/staging-image.yml) — no `docker login ghcr.io` needed on that path.
+# Prereqs: `docker login ghcr.io` done (build path only); Phala dashboard open (restart can be finicky).
 set -euo pipefail
 
-TARGET="${1:?usage: ship-fix.sh staging|prod|pod}"
+TARGET="${1:?usage: ship-fix.sh staging|prod|pod [--no-build]}"
+NOBUILD="${2:-}"
+[ -z "$NOBUILD" ] || [ "$NOBUILD" = "--no-build" ] || { echo "unknown option '$NOBUILD' (only --no-build)" >&2; exit 1; }
+[ -z "$NOBUILD" ] || [ "$TARGET" = staging ] || { echo "--no-build is staging-only: CI builds images only on pushes to staging" >&2; exit 1; }
 TEE="${TEE:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"   # daemon source = this script's checkout (override with TEE=)
 HA="$HOME/projects/hermes-agent"         # where the deploy manifests live
 IMG="ghcr.io/amiller/tee-socket-proxy"
@@ -29,30 +34,59 @@ case "$TARGET" in
   *) echo "unknown target '$TARGET' (valid: staging, prod, pod)" >&2; exit 1 ;;
 esac
 COMMIT=$(git -C "$TEE" rev-parse --short HEAD)
-TAG="$TARGET-$COMMIT"
+# Tag contract with staging-image.yml: staging-<first 7 hex of the sha>. `--short` alone
+# cannot be the contract — its width is object-count dependent (shallow checkout 7, full
+# clone 8) and a width mismatch would make --no-build refuse an image CI did build.
+# `--short` output is always a prefix of the sha, so its first 7 chars are machine-stable.
+TAG="$TARGET-${COMMIT:0:7}"
 
 [ -f "$COMPOSE" ] || { echo "missing compose: $COMPOSE" >&2; exit 1; }
 [ -f "$ENVF" ]    || { echo "missing env (not present in this environment?): $ENVF" >&2; exit 1; }
 
-echo "==> 1/4 build patched image from canonical source ($COMMIT)"
-docker build --build-arg GIT_COMMIT="$COMMIT" -t "$IMG:$TAG" "$TEE"
+if [ "$NOBUILD" = "--no-build" ]; then
+  echo "==> 1/4 build: skipped (--no-build — CI built the image on the push to staging)"
+  echo "==> 2/4 resolve digest of $IMG:$TAG from ghcr (package is public: anonymous pull, no ghcr login)"
+  REPO_PATH="${IMG#ghcr.io/}"
+  TOKEN=$(curl -fsS "https://ghcr.io/token?scope=repository:${REPO_PATH}:pull" \
+    | sed -n 's/.*"token":"\([^"]*\)".*/\1/p')
+  [ -n "$TOKEN" ] || { echo "ghcr refused the anonymous pull token for $REPO_PATH — cannot resolve $TAG" >&2; exit 1; }
+  HDR=$(mktemp)
+  CODE=$(curl -sS -o /dev/null -D "$HDR" -w '%{http_code}' \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Accept: application/vnd.oci.image.index.v1+json" \
+      -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+      -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+      -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+      "https://ghcr.io/v2/${REPO_PATH}/manifests/$TAG") \
+    || { rm -f "$HDR"; echo "ghcr request for $IMG:$TAG failed" >&2; exit 1; }
+  [ "$CODE" = 200 ] \
+    || { rm -f "$HDR"; echo "no CI-built image for this commit: $IMG:$TAG (ghcr HTTP $CODE) — push $COMMIT to staging so CI builds it, or ship without --no-build" >&2; exit 1; }
+  SHA=$(sed -n 's/^[Dd]ocker-[Cc]ontent-[Dd]igest:[[:space:]]*\(sha256:[a-f0-9]\{64\}\).*/\1/p' "$HDR")
+  rm -f "$HDR"
+  [ -n "$SHA" ] || { echo "ghcr returned no Docker-Content-Digest for $TAG — refusing to guess" >&2; exit 1; }
+  DIGEST="$IMG@$SHA"
+  echo "    resolved: $DIGEST"
+else
+  echo "==> 1/4 build patched image from canonical source ($COMMIT)"
+  docker build --build-arg GIT_COMMIT="$COMMIT" -t "$IMG:$TAG" "$TEE"
 
-echo "==> 2/4 push to ghcr"
-# Read the digest out of the push itself. `docker inspect .RepoDigests` was the old way and
-# it is not reliable here: with a buildx/containerd image store the tag can be absent from the
-# classic store even though the push succeeded, and the run dies at the point where the compose
-# would have been pinned (2026-08-24, staging-64004d94).
-PUSH_LOG=$(mktemp)
-docker push "$IMG:$TAG" | tee "$PUSH_LOG"
-SHA=$(sed -n 's/.*digest: \(sha256:[a-f0-9]\{64\}\).*/\1/p' "$PUSH_LOG" | tail -1)
-rm -f "$PUSH_LOG"
-[ -n "$SHA" ] || { echo "push printed no digest — refusing to guess what was pushed" >&2; exit 1; }
-DIGEST="$IMG@$SHA"
-echo "    pushed: $DIGEST"
+  echo "==> 2/4 push to ghcr"
+  # Read the digest out of the push itself. `docker inspect .RepoDigests` was the old way and
+  # it is not reliable here: with a buildx/containerd image store the tag can be absent from the
+  # classic store even though the push succeeded, and the run dies at the point where the compose
+  # would have been pinned (2026-08-24, staging-64004d94).
+  PUSH_LOG=$(mktemp)
+  docker push "$IMG:$TAG" | tee "$PUSH_LOG"
+  SHA=$(sed -n 's/.*digest: \(sha256:[a-f0-9]\{64\}\).*/\1/p' "$PUSH_LOG" | tail -1)
+  rm -f "$PUSH_LOG"
+  [ -n "$SHA" ] || { echo "push printed no digest — refusing to guess what was pushed" >&2; exit 1; }
+  DIGEST="$IMG@$SHA"
+  echo "    pushed: $DIGEST"
+fi
 
 echo "==> 3/4 point $TARGET compose at the new digest"
 sed -i -E "s#${IMG}@sha256:[a-f0-9]+#${DIGEST}#" "$COMPOSE"
-grep -n "$IMG" "$COMPOSE"
+grep -n "$DIGEST" "$COMPOSE" || { echo "compose was not repinned to $DIGEST — no $IMG@sha256 pin to replace; refusing to deploy a stale image" >&2; exit 1; }
 
 echo "==> 4/4 upgrade $CVM CVM (restarts every service in the compose; sealed env re-supplied)"
 phala deploy --cvm-id "$CVM" -c "$COMPOSE" -e "$ENVF" "${KMS[@]}" "${PRELAUNCH[@]}" --wait


### PR DESCRIPTION
## What it does

Adds `.github/workflows/staging-image.yml`: on every push to `staging`, Actions builds the `Dockerfile` (commit baked via `GIT_COMMIT`) and pushes `ghcr.io/amiller/tee-socket-proxy:staging-<short sha>` using only `secrets.GITHUB_TOKEN`, publishing the digest as a job output + step summary. Extends `ship-fix.sh` with `staging --no-build`, which resolves that tag's digest **anonymously** from the ghcr registry API (the package is public — verified), pins it into the staging compose and `phala deploy`s as today, refusing loudly — before touching anything — if CI has not built an image for HEAD. One paragraph in `DEVELOPER_GUIDE.md` documents the two ship paths. Backend-only — no visual evidence.

## What you get by merging

A roll of staging becomes "pin the digest, phala deploy": the ghcr credential disappears from the staging ship path entirely (`--no-build` needs no `docker login ghcr.io`), and every merge to staging is reproducibly built and tagged by CI instead of whichever machine happens to ship.

## Story

Closes #146. Acceptance:
1. push to `staging` → ghcr package version `staging-<short sha>` with `GIT_COMMIT` baked — **post-merge by construction** (the trigger is the staging push itself); YAML parses, `GITHUB_TOKEN` only.
2. `ship-fix.sh staging --no-build` on a CI-built commit rolls webhost-staging, `/_api/version` reports that sha, no `docker build`/`docker push` in the log — **mechanics proven** (transcript below, real ghcr, real tag, real digest cross-checked against `docker manifest inspect`); the actual CVM roll needs the merged commit and the `hermes-agent` compose, which live on the operator side.
3. on a commit CI has not built: exit non-zero, message naming the missing tag, nothing changed — **fully demonstrated** against live ghcr (`staging-5c5dd3e` → HTTP 404, compose byte-identical, zero `phala` calls).
4. workflow uses `secrets.GITHUB_TOKEN` only; no new repository secret — by construction (`permissions: contents: read, packages: write`).

Evidence (Tier 0: no daemon behavior change — no Python touched; the daemon image content for a given commit is unchanged): `.evidence/issue-146/harness-transcript.txt` (committed), all five checks green.

## Risk / what to watch

- **Deliberate disagreement with the pre-spawn plan:** it said "short commit" without pinning a definition. `git rev-parse --short` is object-count dependent — measured here: shallow checkout `e56eb39` (7), full clone `e56eb399` (8) for the same commit — so a naive CI `--short` would push tags the ship machine can never compute, and `--no-build` would refuse images CI did build. The tag is therefore contract-pinned to **first 7 hex of the sha on both sides**; the local build path's `GIT_COMMIT` identity is untouched (`--short` output is always a prefix, so `${COMMIT:0:7}` is machine-stable). Consequence: new tags are 7-char; pre-existing 8-char registry tags stay pullable but are not resolvable by `--no-build` (none were CI-built).
- Plan risk "must avoid the ghcr credential" resolved by measurement: the package is public (anonymous token + manifest GET → 200), so the no-build path needs no credential at all.
- `Dockerfile` / `docker-compose.yaml`: inspection-only, as the plan suspected — untouched.
- **One file the plan missed:** unanchored `workflows/` in `.gitignore` (added in 4dda6d10 to keep stray hermes-agent JS out) also hides `.github/workflows/` — silently untracking this workflow. Anchored to `/workflows/` (root cause, not force-add).
- **Small hardening on a line this change leans on:** the post-sed `grep -n "$IMG"` is now `grep -n "$DIGEST" || fail` — previously, a compose with no digest pin would sed-match nothing, print the stale line, and deploy the *old* image silently. Now it refuses (transcript TEST 5).
- Post-merge, acceptance 1 is self-verifying (the Actions run + package version); acceptance 2's full roll should be run once from a machine with the `hermes-agent` checkout.

## What I could NOT verify

- `test_daemon.py` (the e2e gate) could not run as uid `swarm` on zed: the suite hardcodes `/var/run/docker.sock` (root:docker 0660) for the daemon, this uid is not in `docker` group, no sudo (log saved to `~/paseo-batch/out/146/test.log`). It is the overseer's gate per AGENTS.md — no Python changed, so a green run is expected. The suite also does not exercise `ship-fix.sh` or the workflow (no reference in it).
- The Actions workflow has not executed (needs the merge to `staging` to trigger); YAML validated with PyYAML, and every command in it mirrors the already-proven `ship-fix.sh` flow.

<details><summary>Diff stat / pointers</summary>

```
 .github/workflows/staging-image.yml | 45 +++++++++++++++
 .gitignore                          |  2 +-
 DEVELOPER_GUIDE.md                  |  4 ++
 ship-fix.sh                         | 72 +++++++++++++++++++------
```
Full transcript: `.evidence/issue-146/harness-transcript.txt` on this branch.
</details>