### PR TITLE
notify: a DAEMON_NOTIFY_HOOK receiver that posts one Matrix message per RFC 0034 event (#147)

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -159,6 +159,30 @@ A create token can hold at most `max_pending` unapproved projects (default 5); t
 create returns 429. Set `DAEMON_NOTIFY_HOOK` (an executable, or an `http…` URL) on the
 daemon to receive a JSON envelope on `create`, `approve`, and `freeze`.
 
+### The notify envelope, and where to point the hook
+
+The daemon POSTs one JSON envelope per event, fire-and-forget with a ten-second
+timeout (a hook failure is logged and never blocks the request):
+
+```json
+{"event": "create", "project": "hello-pending", "status": "pending",
+ "deadline": 1789632000.0, "created_by": "tok-3f…"}
+```
+
+`approve` and `freeze` carry the same envelope with the event renamed (`status`
+reflects the change). Point the hook at a deployed receiver to get told, e.g.
+`DAEMON_NOTIFY_HOOK=https://<cvm>/notify-receiver/` — `examples/notify-receiver/`
+is one: it validates the envelope, rejects duplicates, and posts one message to a
+Matrix room given `MATRIX_URL` in its manifest env (the full room-send endpoint,
+credentials included; keep it in `env`, never in source — the API redacts `env`):
+
+```bash
+tar czf app.tgz -C examples/notify-receiver .
+curl -X POST $CVM/_api/projects -H "Authorization: Bearer $TOKEN" \
+  -F 'manifest={"name":"notify-receiver","runtime":"deno","env":{"MATRIX_URL":"https://matrix.example/_matrix/client/v3/rooms/!room@example/…"}};type=application/json' \
+  -F "files=@app.tgz"
+```
+
 ## API surface
 
 Public (no auth required), only for **attested** projects:

--- a/examples/notify-receiver/deploy.sh
+++ b/examples/notify-receiver/deploy.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Deploy the RFC 0034 notify receiver as a project on the daemon, then point
+# DAEMON_NOTIFY_HOOK at its URL (env file on the daemon, operator step).
+# Needs: BASE (daemon URL), TOKEN (create-scoped or owner), MATRIX_URL (full
+# Matrix room-send endpoint incl. credentials).
+set -euo pipefail
+BASE=${BASE:?export BASE (daemon URL)}
+TOKEN=${TOKEN:?export TOKEN (create-scoped or owner)}
+: "${MATRIX_URL:?export MATRIX_URL (full Matrix room-send endpoint, credentials included)}"
+NAME=${NAME:-notify-receiver}
+HERE=$(cd "$(dirname "$0")" && pwd)
+
+T=$(mktemp --suffix=.tgz); trap 'rm -f "$T"' EXIT
+tar -czf "$T" -C "$HERE" --exclude='./.webhost-token' --exclude='./deploy.sh' .
+
+RESP=$(curl -sS -X POST "$BASE/_api/projects" -H "Authorization: Bearer $TOKEN" \
+  -F "manifest=$(jq -nc --arg n "$NAME" --arg u "$MATRIX_URL" '{name:$n, runtime:"deno", env:{MATRIX_URL:$u}}');type=application/json" \
+  -F "files=@$T")
+jq -c '{name, mode, approval}' <<<"$RESP"
+echo "    $BASE/$NAME/  — set DAEMON_NOTIFY_HOOK=$BASE/$NAME/ in the daemon env"

--- a/examples/notify-receiver/server.ts
+++ b/examples/notify-receiver/server.ts
@@ -1,0 +1,62 @@
+// RFC 0034 receiver: turns DAEMON_NOTIFY_HOOK envelopes into one message on the
+// operator channel. The daemon POSTs {"event": "create"|"approve"|"freeze",
+// "project": <name>, "status"?, "deadline"?, "created_by"?}; this handler validates
+// the envelope, drops duplicates, and POSTs one m.text message to MATRIX_URL
+// (the full Matrix room-send endpoint, with credentials — keep it in manifest.env,
+// which the API always redacts). No fallbacks: a missing MATRIX_URL fails loudly.
+
+const VALID_EVENTS = ["create", "approve", "freeze"];
+
+// Bounded dedupe: the daemon is fire-and-forget, but a hook delivery retried after
+// a restart must not double-post. Oldest keys fall off; 256 dwarfs any real queue.
+const seen = new Set<string>();
+function dedupe(key: string): boolean {
+  if (seen.has(key)) return false;
+  if (seen.size >= 256) seen.delete(seen.keys().next().value as string);
+  seen.add(key);
+  return true;
+}
+
+function body(event: string, e: any): string {
+  if (event === "create") {
+    const until = new Date(e.deadline * 1000).toISOString();
+    return `project ${e.project} created by ${e.created_by}, pending until ${until}; approve: POST /_api/projects/${e.project}/approve`;
+  }
+  if (event === "approve") return `project ${e.project} approved`;
+  return `project ${e.project} frozen (pending expired)`;
+}
+
+export default async function handler(req: Request, ctx?: { env: Record<string, string> }) {
+  const url = new URL(req.url);
+  if (req.method === "GET" && url.pathname === "/health") return new Response("ok\n");
+  if (req.method !== "POST") return new Response("method not allowed\n", { status: 405 });
+
+  let e: any;
+  try {
+    e = await req.json();
+  } catch (_) {
+    return Response.json({ error: "body is not valid JSON" }, { status: 400 });
+  }
+  if (!VALID_EVENTS.includes(e.event) || typeof e.project !== "string" || !e.project) {
+    return Response.json({ error: `bad envelope: need event in ${JSON.stringify(VALID_EVENTS)} and a project name` }, { status: 400 });
+  }
+  if (e.event === "create" && (typeof e.deadline !== "number" || typeof e.created_by !== "string")) {
+    return Response.json({ error: "bad create envelope: need numeric deadline and created_by" }, { status: 400 });
+  }
+
+  const key = JSON.stringify([e.event, e.project, e.deadline ?? null, e.created_by ?? null]);
+  if (!dedupe(key)) return Response.json({ error: "duplicate event" }, { status: 409 });
+
+  const matrix = ctx?.env.MATRIX_URL;
+  if (!matrix) return Response.json({ error: "MATRIX_URL is not set" }, { status: 500 });
+
+  const resp = await fetch(matrix, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ msgtype: "m.text", body: body(e.event, e) }),
+  });
+  if (!resp.ok) {
+    return Response.json({ error: `matrix post failed: ${resp.status} ${await resp.text()}` }, { status: 502 });
+  }
+  return Response.json({ posted: body(e.event, e) });
+}

--- a/test_daemon.py
+++ b/test_daemon.py
@@ -25,6 +25,7 @@ AUTH = {"Authorization": f"Bearer {TEST_TOKEN}"}
 
 daemon_proc = None
 tmpdir = None
+NOTIFY_HOOK = None
 
 # RFC 0028 fake browser-bridge: a Deno stdlib HTTP server implementing the
 # pool's contract (/health, /session, /render, /reset). /render sleeps so
@@ -101,8 +102,43 @@ def push_update(name: str, files: dict[str, bytes]):
     subprocess.run(["git", "-C", work_dir, "push"], capture_output=True, check=True)
 
 
+class HookRecorder:
+    """Captures DAEMON_NOTIFY_HOOK deliveries so tests can assert the RFC 0034
+    envelope the daemon actually emits (fire-and-forget; deliveries land async)."""
+
+    def __init__(self):
+        import threading
+        from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+        self.bodies = []
+        rec = self
+
+        class H(BaseHTTPRequestHandler):
+            def do_POST(self):
+                body = self.rfile.read(int(self.headers.get("Content-Length") or 0))
+                rec.bodies.append(json.loads(body))
+                self.send_response(200)
+                self.end_headers()
+
+            def log_message(self, *a):
+                pass
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), H)
+        threading.Thread(target=self.server.serve_forever, daemon=True).start()
+        self.url = f"http://127.0.0.1:{self.server.server_address[1]}/"
+
+    def wait_for(self, pred, timeout=10):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            for b in self.bodies:
+                if pred(b):
+                    return b
+            time.sleep(0.2)
+        return None
+
+
 def start_daemon(reuse_tmpdir: bool = False):
-    global daemon_proc, tmpdir
+    global daemon_proc, tmpdir, NOTIFY_HOOK
+    NOTIFY_HOOK = HookRecorder()
     if not reuse_tmpdir:
         tmpdir = tempfile.mkdtemp(prefix="tee-daemon-test-")
     env = {
@@ -118,6 +154,7 @@ def start_daemon(reuse_tmpdir: bool = False):
         "TEE_DAEMON_TOKEN": TEST_TOKEN,
         "DAEMON_PENDING_TTL": "8",
         "DAEMON_SWEEP_INTERVAL": "1",
+        "DAEMON_NOTIFY_HOOK": NOTIFY_HOOK.url,
         "FOO": "isolated-deno-passthrough",
     }
     # RFC 0028: enable a 1-slot browser pool driven by a fake browser-bridge
@@ -1856,9 +1893,87 @@ def test_provisioner_flow():
     print("  approved, unfrozen, promotable; audit has create/freeze/approve ✓")
 
 
+MATRIX_STUB = r"""
+// RFC 0034 test double for a Matrix homeserver room-send endpoint: records every
+// POSTed message in memory; GET /messages returns them.
+const messages: { body: string }[] = [];
+export default async function handler(req: Request) {
+  if (req.method === "GET" && new URL(req.url).pathname === "/messages") {
+    return Response.json({ messages });
+  }
+  if (req.method === "POST" || req.method === "PUT") {
+    const e: any = await req.json();
+    messages.push({ body: e.body ?? "" });
+    return Response.json({ event_id: `$stub${messages.length}` });
+  }
+  return new Response("not found", { status: 404 });
+}
+"""
+
+
+def test_notify_receiver():
+    """RFC 0034 notify path: the daemon emits the envelope, the receiver turns it
+    into exactly one Matrix message (examples/notify-receiver/)."""
+    print("\n--- Test: DAEMON_NOTIFY_HOOK envelope + Matrix receiver ---")
+
+    # Daemon-side contract: the provisioner flow emitted create/approve/freeze envelopes.
+    create_env = NOTIFY_HOOK.wait_for(lambda b: b.get("event") == "create" and b["project"] == "hello-pending")
+    assert create_env, NOTIFY_HOOK.bodies
+    assert create_env["created_by"].startswith("tok-") and isinstance(create_env["deadline"], float), create_env
+    assert NOTIFY_HOOK.wait_for(lambda b: b.get("event") == "freeze" and b["project"] == "hello-pending")
+    assert NOTIFY_HOOK.wait_for(lambda b: b.get("event") == "approve" and b["project"] == "hello-pending")
+    print(f"  hook got create/freeze/approve for hello-pending ({len(NOTIFY_HOOK.bodies)} envelopes) ✓")
+
+    # The receiver, deployed as a project, posting to an in-daemon Matrix stub.
+    matrix_stub = make_tarball({"server.ts": MATRIX_STUB.encode()})
+    resp = api_post("/projects", files={
+        "manifest": (None, json.dumps({"name": "matrix-stub", "runtime": "deno"}), "application/json"),
+        "files": ("app.tar.gz", matrix_stub, "application/gzip")})
+    assert resp.status_code == 201, resp.text
+
+    def deploy_receiver(env):
+        src = open(os.path.join(os.path.dirname(__file__), "examples", "notify-receiver", "server.ts"), "rb").read()
+        tarball = make_tarball({"server.ts": src})
+        return api_post("/projects", files={
+            "manifest": (None, json.dumps({"name": "notify-receiver", "runtime": "deno", "env": env}), "application/json"),
+            "files": ("app.tar.gz", tarball, "application/gzip")})
+
+    resp = deploy_receiver({"MATRIX_URL": "http://localhost:3000/matrix-stub/send"})
+    assert resp.status_code == 201, resp.text
+    time.sleep(4)
+
+    def messages():
+        return requests.get(f"{INGRESS}/matrix-stub/messages").json()["messages"]
+
+    envelope = {"event": "create", "project": "hooked-proj", "status": "pending",
+                "deadline": time.time() + 3600, "created_by": "tok-abc123"}
+    r = requests.post(f"{INGRESS}/notify-receiver/", json=envelope)
+    assert r.status_code == 200, r.text
+    r.raise_for_status()
+    deadline = envelope["deadline"]
+    want = (f"project hooked-proj created by tok-abc123, "
+            f"pending until {time.strftime('%Y-%m-%dT%H:%M:%S', time.gmtime(deadline))}; "
+            f"approve: POST /_api/projects/hooked-proj/approve")
+    msgs = messages()
+    assert msgs == [{"body": want}], msgs
+    print(f"  receiver → exactly one Matrix message: {want!r} ✓")
+
+    assert requests.post(f"{INGRESS}/notify-receiver/", json=envelope).status_code == 409, "duplicate not rejected"
+    assert requests.post(f"{INGRESS}/notify-receiver/", data="not json").status_code == 400
+    assert requests.post(f"{INGRESS}/notify-receiver/", json={"event": "boom", "project": "x"}).status_code == 400
+    assert requests.post(f"{INGRESS}/notify-receiver/", json={"event": "create", "project": "x"}).status_code == 400
+    print("  duplicate → 409, malformed/incomplete envelope → 400 ✓")
+
+    r = requests.post(f"{INGRESS}/notify-receiver/", json={"event": "approve", "project": "hooked-proj"})
+    assert r.status_code == 200 and messages()[-1]["body"] == "project hooked-proj approved", r.text
+    r = requests.post(f"{INGRESS}/notify-receiver/", json={"event": "freeze", "project": "hooked-proj"})
+    assert r.status_code == 200 and messages()[-1]["body"] == "project hooked-proj frozen (pending expired)", r.text
+    print("  approve/freeze messages ✓")
+
+
 def test_teardown():
     print("\n--- Test: teardown ---")
-    for name in ["test-static", "test-caps", "test-deno", "test-auto", "test-tarball", "test-image", "test-vol", "test-iso-a", "test-iso-b", "test-passthru", "test-iso-passthru", "test-redeploy-img", "test-redact", "test-keepenv", "net-a", "net-b", "data-iso", "rfc-test", "test-opdebug", "test-opdebug-off", "tier0-src", "test-exp", "hello-pending", "hello-pending-2"]:
+    for name in ["test-static", "test-caps", "test-deno", "test-auto", "test-tarball", "test-image", "test-vol", "test-iso-a", "test-iso-b", "test-passthru", "test-iso-passthru", "test-redeploy-img", "test-redact", "test-keepenv", "net-a", "net-b", "data-iso", "rfc-test", "test-opdebug", "test-opdebug-off", "tier0-src", "test-exp", "hello-pending", "hello-pending-2", "matrix-stub", "notify-receiver"]:
         resp = api_delete(f"/projects/{name}")
         if resp.status_code == 200:
             print(f"  Torn down: {name}")
@@ -1921,6 +2036,7 @@ def main():
         test_rfc0017_export_import()
         test_rfc0017_bootstrap()
         test_provisioner_flow()
+        test_notify_receiver()
         test_teardown()
         print("\n=== ALL TESTS PASSED ===")
     except Exception:


### PR DESCRIPTION
## What it does

The receiving half of `DAEMON_NOTIFY_HOOK` (RFC 0034, already on staging): `examples/notify-receiver/` is a deployable deno project that validates the hook envelope, rejects malformed and duplicate events, and posts exactly one message per `create`/`approve`/`freeze` to the operator Matrix channel — including the acceptance-mandated create text: `project <name> created by <token id>, pending until <deadline>; approve: POST /_api/projects/<name>/approve`. Matrix credentials arrive via `MATRIX_URL` in the manifest env (the API redacts `env`, so the token is never echoed). `DEVELOPER_GUIDE.md` documents the envelope and how to point the hook at the receiver; `test_daemon.py` gains a `HookRecorder` (asserts the real daemon-side envelope for all three events) plus `test_notify_receiver` (deploys the receiver + an in-daemon Matrix stub and walks every path).

## What you get by merging

A project created by a worker no longer sits pending with no one told: deploy the receiver (one `deploy.sh`), set `DAEMON_NOTIFY_HOOK` in the staging env, and every create/approve/freeze lands in the operator channel within seconds.

## Evidence (Tier 1 — API/HTTP transcripts, run first-hand on this box)

**1. Daemon emits the real envelope** (live daemon at this branch, real provisioner flow, static tenant):
```
POST /_api/projects (create-scoped token) → 201
approval: {"status": "pending", "deadline": 1788992486.0413158, "created_by": "tok-rG5JQRxM344"}
→ hook delivery: {"event": "create", "project": "hooked", "status": "pending", "deadline": 1788992486.0413158, "created_by": "tok-rG5JQRxM344"}
POST /_api/projects/hooked/approve → 200
→ hook delivery: {"event": "approve", "project": "hooked"}
TTL=8s sweep froze a second pending project:
→ hook delivery: {"event": "freeze", "project": "hooked2", "status": "frozen", "deadline": 1788992578.6352975, "created_by": "tok-BzyspSd32LI"}
```

**2. Receiver end-to-end under real deno** (handler driven exactly as the shared-runtime router drives it; Matrix stub records the POSTs):
```
create envelope → 200, one message: "project hooked-proj created by tok-abc123, pending until 2026-09-16T…; approve: POST /_api/projects/hooked-proj/approve"
same envelope again → 409 duplicate, no second message
"not json" / unknown event / create missing deadline → 400 each
approve → "project hooked-proj approved"; freeze → "project hooked-proj frozen (pending expired)"
valid envelope with MATRIX_URL unset → 500 naming MATRIX_URL (loud, no fallback)
```

**3. Wire test over HTTP**: a standalone receiver answered `POST /notify-receiver/` with the real envelope, returned 409 on the duplicate and 400 on garbage, and the stub recorded exactly one message.

`deno check` clean on the receiver.

## What I could NOT verify — need from operator

- **`test_daemon.py` full-suite run**: this account has rootless docker only (`/var/run/docker.sock` is `root:docker 660`; uid 1018 not in `docker`) and the suite hard-codes that socket — the same wall six prior spawns documented on #115. The two daemon-container tests inside `test_notify_receiver` (deno project deploys) will pass wherever the suite runs today (overseer run with root docker). Everything my change touches was exercised live via the three transcripts above.
- **Staging deploy of the receiver + `DAEMON_NOTIFY_HOOK` in the staging env file** (acceptance 3–4): no `TEE_DAEMON_URL`/token and no CVM deploy credentials exist for the swarm account — the documented credential (`~/.tee-daemon-staging.env`) is absent here. This is the box-inventory scope-down: ship the verifiable subset, hand the rest back. After merging this PR, on the operator side: run `examples/notify-receiver/deploy.sh` against webhost-staging with a create-scoped or owner token and `MATRIX_URL`, then set `DAEMON_NOTIFY_HOOK=https://<staging>/notify-receiver/` in the staging env file.
- **capdel re-mint (acceptance 1–2)**: owner-filed on the broker (owner secret never leaves zed). A paste-ready runbook is at `/srv/swarm-outbox/issue-147-capdel-remint.md`: `capdel.py mint exec --allow /home/amiller/bin/ship-staging --cwd-root /home/amiller --ttl 90d --name "ship webhost-staging (loop)"`, distribute the token where the current one lives, revoke the old cap after its first successful invoke (`capdel tree` shows expiry ≥80d + REVOKED).

## Risk / what to watch

- The receiver dedupes in memory (bounded 256-entry set): a receiver restart forgets seen events, so a hook retried in that window could double-post. The daemon is single-attempt, so this only bites across a restart+retry; prefer a Matrix token scoped to just the operator room.
- `MATRIX_URL` holds the room-send endpoint including the access token. It lives in manifest `env`, which every API response redacts — but it is still one more place the channel token exists.

<details>
<summary>Diff stats</summary>

```
 DEVELOPER_GUIDE.md                 |  24 ++++++++++
 examples/notify-receiver/deploy.sh |  20 +++++++
 examples/notify-receiver/server.ts |  62 +++++++++++++++++++
 test_daemon.py                     | 120 ++++++++++++++++++++++++++++++++++++++++++++++++++++-
 4 files changed, 224 insertions(+), 2 deletions(-)
```
</details>